### PR TITLE
Add SLT SLTU instructions

### DIFF
--- a/src/instructions/mod.rs
+++ b/src/instructions/mod.rs
@@ -167,6 +167,30 @@ pub(super) enum Instruction {
         rs2: Register,
     },
 
+    /// # Set Less Than
+    ///
+    /// Place the value 1 in register rd if register rs1 is less than register rs2 when both are
+    /// treated as signed numbers, else 0 is written to rd.
+    ///
+    /// `rd <- rs1 <s rs2`
+    SLT {
+        rd: Register,
+        rs1: Register,
+        rs2: Register,
+    },
+
+    /// # Set Less Than Unsigned
+    ///
+    /// Place the value 1 in register rd if register rs1 is less than register rs2 when both are
+    /// treated as unsigned numbers, else 0 is written to rd.
+    ///
+    /// `rd <- rs1 <u rs2`
+    SLTU {
+        rd: Register,
+        rs1: Register,
+        rs2: Register,
+    },
+
     /// # Subract
     ///
     /// Arithmetic overflow is ignored and the result is simply the low XLEN bits of the
@@ -268,6 +292,16 @@ impl From<u32> for Instruction {
                     rs2: *Rs2::from(value),
                 },
                 (0b_000, 0b_0100000) => Instruction::SUB {
+                    rd: *Rd::from(value),
+                    rs1: *Rs1::from(value),
+                    rs2: *Rs2::from(value),
+                },
+                (0b_010, 0b_0000000) => Instruction::SLT {
+                    rd: *Rd::from(value),
+                    rs1: *Rs1::from(value),
+                    rs2: *Rs2::from(value),
+                },
+                (0b_011, 0b_0000000) => Instruction::SLTU {
                     rd: *Rd::from(value),
                     rs1: *Rs1::from(value),
                     rs2: *Rs2::from(value),
@@ -458,6 +492,30 @@ mod test {
                 rd: Register::SP,
                 rs1: Register::S11,
                 rs2: Register::T4,
+            }
+        );
+    }
+
+    #[test]
+    fn stl_from_i32() {
+        assert_eq!(
+            Instruction::from(u32::from_le(0b_0000000_11100_10011_010_00110_0110011)),
+            Instruction::SLT {
+                rd: Register::T1,
+                rs1: Register::S3,
+                rs2: Register::T3,
+            }
+        );
+    }
+
+    #[test]
+    fn stlu_from_i32() {
+        assert_eq!(
+            Instruction::from(u32::from_le(0b_0000000_11000_10001_011_01110_0110011)),
+            Instruction::SLTU {
+                rd: Register::A4,
+                rs1: Register::A7,
+                rs2: Register::S8,
             }
         );
     }

--- a/src/instructions/pseudoinstructions.rs
+++ b/src/instructions/pseudoinstructions.rs
@@ -63,7 +63,7 @@ impl DoubleEndedIterator for PseudoinstructionMappingIter {
 impl Instruction {
     /// # Load Immediate
     ///
-    /// Note: This pseudo Instruction desugars to a load upper Immediate
+    /// Note: This pseudoinstruction desugars to a load upper Immediate
     /// and a add immediate for the lower bits.
     /// See [ref](https://github.com/riscv-non-isa/riscv-asm-manual/blob/master/riscv-asm.md#load-immediate).
     #[allow(non_snake_case)]
@@ -93,7 +93,7 @@ impl Instruction {
     ///
     /// Performs a bitwise logical inversion of register rs and places the result in rd.
     ///
-    /// Note: This pseudo Instruction desugars to `XORI rd, rs, -1`.
+    /// Note: This pseudoinstruction desugars to `XORI rd, rs, -1`.
     /// See [ref](https://github.com/riscv-non-isa/riscv-asm-manual/blob/master/riscv-asm.md#-a-listing-of-standard-risc-v-pseudoinstructions).
     #[allow(non_snake_case)]
     pub(crate) fn NOT(rd: Register, rs: Register) -> PseudoinstructionMappingIter {
@@ -108,7 +108,7 @@ impl Instruction {
     ///
     /// Two compliment negation.
     ///
-    /// Note: This pseudo Instruction desugars to `SUB rd, x0, rs`.
+    /// Note: This pseudoinstruction desugars to `SUB rd, x0, rs`.
     /// See [ref](https://github.com/riscv-non-isa/riscv-asm-manual/blob/master/riscv-asm.md#-a-listing-of-standard-risc-v-pseudoinstructions).
     #[allow(non_snake_case)]
     pub(crate) fn NEG(rd: Register, rs: Register) -> PseudoinstructionMappingIter {
@@ -123,7 +123,7 @@ impl Instruction {
     ///
     /// Move the value in rs to rd.
     ///
-    /// Note: This pseudo Instruction desugars to `ADDI rd, rs, 0`.
+    /// Note: This pseudoinstruction desugars to `ADDI rd, rs, 0`.
     /// See [ref](https://github.com/riscv-non-isa/riscv-asm-manual/blob/master/riscv-asm.md#-a-listing-of-standard-risc-v-pseudoinstructions).
     #[allow(non_snake_case)]
     pub(crate) fn MOV(rd: Register, rs: Register) -> PseudoinstructionMappingIter {
@@ -134,11 +134,27 @@ impl Instruction {
         })
     }
 
+    /// # Set Equal Zero
+    ///
+    /// Sets the destination register to 1 if `rs` is zero, otherwises set the destination register
+    /// to 1.
+    ///
+    /// Note: This pseudoinstruction desugars to `SLTUI rd, rs, 1`.
+    /// See [ref](https://github.com/riscv-non-isa/riscv-asm-manual/blob/master/riscv-asm.md#-a-listing-of-standard-risc-v-pseudoinstructions).
+    #[allow(non_snake_case)]
+    pub(crate) fn SEQZ(rd: Register, rs: Register) -> PseudoinstructionMappingIter {
+        PseudoinstructionMappingIter::One(Instruction::SLTIU {
+            rd,
+            rs1: rs,
+            imm: 1,
+        })
+    }
+
     /// # NOP
     ///
     /// This instruction does nothing.
     ///
-    /// Note: This pseudo Instruction desugars to `ADDI x0, x0, 0`.
+    /// Note: This pseudoinstruction desugars to `ADDI x0, x0, 0`.
     /// See [ref](https://github.com/riscv-non-isa/riscv-asm-manual/blob/master/riscv-asm.md#-a-listing-of-standard-risc-v-pseudoinstructions).
     #[allow(non_snake_case)]
     pub(crate) const NOP: PseudoinstructionMappingIter =

--- a/src/instructions/pseudoinstructions.rs
+++ b/src/instructions/pseudoinstructions.rs
@@ -137,7 +137,7 @@ impl Instruction {
     /// # Set Equal Zero
     ///
     /// Sets the destination register to 1 if `rs` is zero, otherwises set the destination register
-    /// to 1.
+    /// to 0.
     ///
     /// Note: This pseudoinstruction desugars to `SLTUI rd, rs, 1`.
     /// See [ref](https://github.com/riscv-non-isa/riscv-asm-manual/blob/master/riscv-asm.md#-a-listing-of-standard-risc-v-pseudoinstructions).
@@ -147,6 +147,54 @@ impl Instruction {
             rd,
             rs1: rs,
             imm: 1,
+        })
+    }
+
+    /// # Set Not Equal Zero
+    ///
+    /// Sets the destination register to 1 if `rs` is not equal to zero, otherwises set the destination register
+    /// to 0.
+    ///
+    /// Note: This pseudoinstruction desugars to `SLTU rd, x0, rs`.
+    /// See [ref](https://github.com/riscv-non-isa/riscv-asm-manual/blob/master/riscv-asm.md#-a-listing-of-standard-risc-v-pseudoinstructions).
+    #[allow(non_snake_case)]
+    pub(crate) fn SNEZ(rd: Register, rs: Register) -> PseudoinstructionMappingIter {
+        PseudoinstructionMappingIter::One(Instruction::SLTU {
+            rd,
+            rs1: Register::ZERO,
+            rs2: rs,
+        })
+    }
+
+    /// # Set Less Than Zero
+    ///
+    /// Sets the destination register to 1 if `rs` is less than zero, otherwises set the destination register
+    /// to 0.
+    ///
+    /// Note: This pseudoinstruction desugars to `SLT rd, rs, x0`.
+    /// See [ref](https://github.com/riscv-non-isa/riscv-asm-manual/blob/master/riscv-asm.md#-a-listing-of-standard-risc-v-pseudoinstructions).
+    #[allow(non_snake_case)]
+    pub(crate) fn SLTZ(rd: Register, rs: Register) -> PseudoinstructionMappingIter {
+        PseudoinstructionMappingIter::One(Instruction::SLT {
+            rd,
+            rs1: rs,
+            rs2: Register::ZERO,
+        })
+    }
+
+    /// # Set Greater Than Zero
+    ///
+    /// Sets the destination register to 1 if `rs` is greater than zero, otherwises set the destination register
+    /// to 0.
+    ///
+    /// Note: This pseudoinstruction desugars to `SLT rd, x0, rs`.
+    /// See [ref](https://github.com/riscv-non-isa/riscv-asm-manual/blob/master/riscv-asm.md#-a-listing-of-standard-risc-v-pseudoinstructions).
+    #[allow(non_snake_case)]
+    pub(crate) fn SGLZ(rd: Register, rs: Register) -> PseudoinstructionMappingIter {
+        PseudoinstructionMappingIter::One(Instruction::SLT {
+            rd,
+            rs1: Register::ZERO,
+            rs2: rs,
         })
     }
 

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -98,11 +98,11 @@ where
             }
             Instruction::SLT { rd, rs1, rs2 } => {
                 self.registers[rd] = (self.registers[rs1] < self.registers[rs2]).into()
-            },
+            }
             Instruction::SLTU { rd, rs1, rs2 } => {
                 self.registers[rd] =
                     (self.registers[rs1].as_unsigned() < self.registers[rs2].as_unsigned()).into()
-            },
+            }
             Instruction::LW { rd, rs1, offset } => {
                 self.registers[rd] = self.memory.load_word(
                     self.registers[rs1]
@@ -292,6 +292,63 @@ mod test {
             Instruction::SEQZ(Register::A3, Register::A1),
             changes: {registers: {a1: 1}},
             to: {registers: {a1: 1, a3: 0}},
+        );
+    }
+
+    #[test]
+    fn execute_snez() {
+        test_execute_many!(
+            Instruction::SNEZ(Register::A3, Register::A1),
+            changes: {registers: {a1: -1}},
+            to: {registers: {a1: -1, a3: 1}},
+        );
+        test_execute_many!(
+            Instruction::SNEZ(Register::A3, Register::A1),
+            changes: {registers: {a1: 0}},
+            to: {registers: {a1: 0, a3: 0}},
+        );
+        test_execute_many!(
+            Instruction::SNEZ(Register::A3, Register::A1),
+            changes: {registers: {a1: 1}},
+            to: {registers: {a1: 1, a3: 1}},
+        );
+    }
+
+    #[test]
+    fn execute_sltz() {
+        test_execute_many!(
+            Instruction::SLTZ(Register::A3, Register::A1),
+            changes: {registers: {a1: -1}},
+            to: {registers: {a1: -1, a3: 1}},
+        );
+        test_execute_many!(
+            Instruction::SLTZ(Register::A3, Register::A1),
+            changes: {registers: {a1: 0}},
+            to: {registers: {a1: 0, a3: 0}},
+        );
+        test_execute_many!(
+            Instruction::SLTZ(Register::A3, Register::A1),
+            changes: {registers: {a1: 1}},
+            to: {registers: {a1: 1, a3: 0}},
+        );
+    }
+
+    #[test]
+    fn execute_sgtz() {
+        test_execute_many!(
+            Instruction::SGLZ(Register::A3, Register::A1),
+            changes: {registers: {a1: -1}},
+            to: {registers: {a1: -1, a3: 0}},
+        );
+        test_execute_many!(
+            Instruction::SGLZ(Register::A3, Register::A1),
+            changes: {registers: {a1: 0}},
+            to: {registers: {a1: 0, a3: 0}},
+        );
+        test_execute_many!(
+            Instruction::SGLZ(Register::A3, Register::A1),
+            changes: {registers: {a1: 1}},
+            to: {registers: {a1: 1, a3: 1}},
         );
     }
 

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -270,6 +270,25 @@ mod test {
     }
 
     #[test]
+    fn execute_seqz() {
+        test_execute_many!(
+            Instruction::SEQZ(Register::A3, Register::A1),
+            changes: {registers: {a1: -1}},
+            to: {registers: {a1: -1, a3: 0}},
+        );
+        test_execute_many!(
+            Instruction::SEQZ(Register::A3, Register::A1),
+            changes: {registers: {a1: 0}},
+            to: {registers: {a1: 0, a3: 1}},
+        );
+        test_execute_many!(
+            Instruction::SEQZ(Register::A3, Register::A1),
+            changes: {registers: {a1: 1}},
+            to: {registers: {a1: 1, a3: 0}},
+        );
+    }
+
+    #[test]
     fn execute_nop() {
         test_execute_many!(
             Instruction::NOP,
@@ -350,6 +369,16 @@ mod test {
             Instruction::SLTIU{rd: Register::T4, rs1: Register::T1, imm: -43},
             changes: {registers: {t1: 42}},
             to: {registers: {t1: 42, t4: 1}},
+        );
+        test_execute!(
+            Instruction::SLTIU{rd: Register::T4, rs1: Register::T1, imm: 1},
+            changes: {registers: {t1: 42}},
+            to: {registers: {t1: 42, t4: 0}},
+        );
+        test_execute!(
+            Instruction::SLTIU{rd: Register::T4, rs1: Register::T1, imm: 1},
+            changes: {registers: {t1: 0}},
+            to: {registers: {t1: 0, t4: 1}},
         );
     }
 

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -96,6 +96,13 @@ where
             Instruction::SUB { rd, rs1, rs2 } => {
                 self.registers[rd] = self.registers[rs1].wrapping_sub(&self.registers[rs2])
             }
+            Instruction::SLT { rd, rs1, rs2 } => {
+                self.registers[rd] = (self.registers[rs1] < self.registers[rs2]).into()
+            },
+            Instruction::SLTU { rd, rs1, rs2 } => {
+                self.registers[rd] =
+                    (self.registers[rs1].as_unsigned() < self.registers[rs2].as_unsigned()).into()
+            },
             Instruction::LW { rd, rs1, offset } => {
                 self.registers[rd] = self.memory.load_word(
                     self.registers[rs1]
@@ -541,6 +548,54 @@ mod test {
             Instruction::SUB { rd: Register::T3, rs1: Register::T1, rs2: Register::T2, },
             changes: {registers: {t1: 45, t2: 3}},
             to: {registers: {t1: 45, t2: 3, t3: 42}},
+        );
+    }
+
+    #[test]
+    fn execute_slt() {
+        test_execute!(
+            Instruction::SLT{rd: Register::T4, rs1: Register::T1, rs2: Register::T3},
+            changes: {registers: {t1: 42, t3: 43}},
+            to: {registers: {t1: 42, t4: 1, t3: 43}},
+        );
+        test_execute!(
+            Instruction::SLT{rd: Register::T4, rs1: Register::T1, rs2: Register::T3},
+            changes: {registers: {t1: 42, t4: 100, t3: 42}},
+            to: {registers: {t1: 42, t4: 0, t3: 42}},
+        );
+        test_execute!(
+            Instruction::SLT{rd: Register::T4, rs1: Register::T1, rs2: Register::T3},
+            changes: {registers: {t1: 42, t3: -43}},
+            to: {registers: {t1: 42, t4: 0, t3: -43}},
+        );
+    }
+
+    #[test]
+    fn execute_sltu() {
+        test_execute!(
+            Instruction::SLTU{rd: Register::T4, rs1: Register::T1, rs2: Register::A4},
+            changes: {registers: {t1: 42, a4: 43}},
+            to: {registers: {t1: 42, t4: 1, a4: 43}},
+        );
+        test_execute!(
+            Instruction::SLTU{rd: Register::T4, rs1: Register::T1, rs2: Register::A4},
+            changes: {registers: {t1: 42, t4: 100, a4: 42}},
+            to: {registers: {t1: 42, t4: 0, a4: 42}},
+        );
+        test_execute!(
+            Instruction::SLTU{rd: Register::T4, rs1: Register::T1, rs2: Register::A4},
+            changes: {registers: {t1: 42, a4: -43}},
+            to: {registers: {t1: 42, t4: 1, a4: -43}},
+        );
+        test_execute!(
+            Instruction::SLTU{rd: Register::T4, rs1: Register::T1, rs2: Register::A4},
+            changes: {registers: {t1: 42, a4: 1}},
+            to: {registers: {t1: 42, t4: 0, a4: 1}},
+        );
+        test_execute!(
+            Instruction::SLTU{rd: Register::T4, rs1: Register::T1, rs2: Register::A4},
+            changes: {registers: {t1: 0, a4: 1}},
+            to: {registers: {t1: 0, t4: 1, a4: 1}},
         );
     }
 


### PR DESCRIPTION
Add support for the SLT (Set less than) and SLTU (set less than unsigned) instructions.

This PR also add the SNEZ (set not equal zero), SGTZ (set greater than zero), and SLTZ (set less than zero) pseudoinstructions.

- Add pseudoinstruction SEQZ (set equal to zero)
- Add SLT and SLTU instructions
- Add pseudoinstructions SNEZ, SGTZ, SLTZ
