### PR TITLE
Add csr struct to processor state

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,6 @@ Feel free to contribute and get involved if you would like to learn more about a
   - [ ] CSRRCI
   - [ ] ECALL
   - [ ] EBREAK
-  - [ ] URET
-  - [ ] SRET
-  - [ ] MRET
-  - [ ] WFI
-  - [ ] SFENCE.VMA
   - [X] LB
   - [X] LH
   - [X] LW
@@ -66,6 +61,19 @@ Feel free to contribute and get involved if you would like to learn more about a
   - [ ] BGE
   - [ ] BLTU
   - [ ] BGEU
+
+</details>
+
+<details open>
+  <summary>
+    - [ ] Implement privileged RV32I:
+  </summary>
+
+  - [ ] URET
+  - [ ] SRET
+  - [ ] MRET
+  - [ ] WFI
+  - [ ] SFENCE.VMA
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Feel free to contribute and get involved if you would like to learn more about a
   - [ ] FENCE.I
   - [x] CSRRW
   - [x] CSRRS
-  - [ ] CSRRC
+  - [x] CSRRC
   - [ ] CSRRWI
   - [ ] CSRRSI
   - [ ] CSRRCI

--- a/README.md
+++ b/README.md
@@ -7,6 +7,68 @@ A RISC-V interpreter written in Rust.
 This project is in early stages and it primarily being embarked upon as a learning exercise.
 Feel free to contribute and get involved if you would like to learn more about assembly and RISC-V.
 
+## TODO
+
+<details open>
+  <summary>
+    - [ ] Implement RV32I:
+  </summary>
+
+  - [x] LUI
+  - [x] AUIPC
+  - [x] ADDI
+  - [x] SLTI
+  - [x] SLTUI
+  - [x] XORI
+  - [x] ORI
+  - [x] ANDI
+  - [x] SLLI
+  - [x] SRLI
+  - [x] SRAI
+  - [x] ADD
+  - [x] SUB
+  - [x] SLL
+  - [x] SLT
+  - [x] SLTU
+  - [x] XOR
+  - [x] SRL
+  - [x] SRA
+  - [x] OR
+  - [x] AND
+  - [ ] FENCE
+  - [ ] FENCE.I
+  - [x] CSRRW
+  - [x] CSRRS
+  - [ ] CSRRC
+  - [ ] CSRRWI
+  - [ ] CSRRSI
+  - [ ] CSRRCI
+  - [ ] ECALL
+  - [ ] EBREAK
+  - [ ] URET
+  - [ ] SRET
+  - [ ] MRET
+  - [ ] WFI
+  - [ ] SFENCE.VMA
+  - [X] LB
+  - [X] LH
+  - [X] LW
+  - [X] LBU
+  - [X] LHU
+  - [X] SB
+  - [X] SH
+  - [X] SW
+  - [ ] JAL
+  - [ ] JALR
+  - [ ] BEQ
+  - [ ] BNE
+  - [ ] BLT
+  - [ ] BGE
+  - [ ] BLTU
+  - [ ] BGEU
+
+</details>
+
 ## Provisional plan
 
 - Implement basic model of the processor, instructions, stack and heap (based on a useful subset of all the instructions)

--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ Feel free to contribute and get involved if you would like to learn more about a
   - [x] CSRRW
   - [x] CSRRS
   - [x] CSRRC
-  - [ ] CSRRWI
-  - [ ] CSRRSI
-  - [ ] CSRRCI
+  - [X] CSRRWI
+  - [X] CSRRSI
+  - [X] CSRRCI
   - [ ] ECALL
   - [ ] EBREAK
   - [X] LB

--- a/src/csr.rs
+++ b/src/csr.rs
@@ -1,0 +1,97 @@
+use std::sync::atomic::{AtomicI32, AtomicI64, Ordering::SeqCst};
+
+const CSR_SIZE: usize = 4096;
+
+pub trait CSR {
+    type Register;
+    fn read_write(&self, index: usize, value: Self::Register) -> Self::Register;
+    fn set_bits(&self, index: usize, value: Self::Register) -> Self::Register;
+    fn clear_bits(&self, index: usize, value: Self::Register) -> Self::Register;
+}
+
+#[derive(Debug)]
+pub struct CSR32 {
+    registers: Vec<AtomicI32>,
+}
+
+#[derive(Debug)]
+pub struct CSR64 {
+    registers: Vec<AtomicI64>,
+}
+
+macro_rules! implement_csr {
+    ($struct_name: ty, $register_type:ty) => {
+        impl $struct_name {
+            fn new() -> Self {
+                let mut registers = Vec::default();
+                registers.resize_with(CSR_SIZE, Default::default);
+                Self { registers }
+            }
+        }
+        impl Default for $struct_name {
+            fn default() -> Self {
+                Self::new()
+            }
+        }
+        impl CSR for $struct_name {
+            type Register = $register_type;
+
+            fn read_write(&self, index: usize, value: Self::Register) -> Self::Register {
+                self.registers[index].swap(value, SeqCst)
+            }
+
+            fn set_bits(&self, index: usize, value: Self::Register) -> Self::Register {
+                self.registers[index].fetch_or(value, SeqCst)
+            }
+
+            fn clear_bits(&self, index: usize, value: Self::Register) -> Self::Register {
+                self.registers[index].fetch_and(!value, SeqCst)
+            }
+        }
+    };
+}
+
+implement_csr!(CSR32, i32);
+implement_csr!(CSR64, i64);
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn initial_value_zero() {
+        let csr_32 = CSR32::default();
+        let csr_64 = CSR32::default();
+
+        assert_eq!(csr_32.set_bits(42, 0), 0);
+        assert_eq!(csr_64.set_bits(42, 0), 0);
+    }
+
+    #[test]
+    fn set_bits() {
+        let csr_32 = CSR32::default();
+        let csr_64 = CSR32::default();
+
+        assert_eq!(csr_32.set_bits(42, -1), 0);
+        assert_eq!(csr_64.set_bits(42, -1), 0);
+        assert_eq!(csr_32.set_bits(42, 0), -1);
+        assert_eq!(csr_64.set_bits(42, 0), -1);
+        assert_eq!(csr_32.set_bits(42, -1), -1);
+        assert_eq!(csr_64.set_bits(42, -1), -1);
+        assert_eq!(csr_32.set_bits(42, 0), -1);
+        assert_eq!(csr_64.set_bits(42, 0), -1);
+    }
+
+    #[test]
+    fn clear_bits() {
+        let csr_32 = CSR32::default();
+        let csr_64 = CSR32::default();
+
+        assert_eq!(csr_32.set_bits(42, -1), 0);
+        assert_eq!(csr_64.set_bits(42, -1), 0);
+        assert_eq!(csr_32.clear_bits(42, -1), -1);
+        assert_eq!(csr_64.clear_bits(42, -1), -1);
+        assert_eq!(csr_32.set_bits(42, 0), 0);
+        assert_eq!(csr_64.set_bits(42, 0), 0);
+    }
+}

--- a/src/csr.rs
+++ b/src/csr.rs
@@ -6,6 +6,10 @@ const CSR_SIZE: usize = 4096;
 /// The control status registers.
 pub trait CSR {
     type Register;
+    /// Reads the value of the CSR.
+    ///
+    /// Panics if index is out of bounds (>`CSR_SIZE`)
+    fn read(&self, index: u16) -> Self::Register;
     /// Swaps the value for the value at `index`.
     ///
     /// Panics if index is out of bounds (>`CSR_SIZE`)
@@ -84,6 +88,10 @@ macro_rules! implement_csr {
         }
         impl CSR for $struct_name {
             type Register = $register_type;
+
+            fn read(&self, index: u16) -> Self::Register {
+                self.registers[index as usize].load(SeqCst)
+            }
 
             fn read_write(&self, index: u16, value: Self::Register) -> Self::Register {
                 self.registers[index as usize].swap(value, SeqCst)

--- a/src/csr.rs
+++ b/src/csr.rs
@@ -40,7 +40,7 @@ pub trait CSR {
 /// Additionally some registers are read only.
 #[derive(Debug)]
 pub struct CSR32 {
-    registers: Vec<AtomicI32>,
+    registers: Box<[AtomicI32]>,
 }
 
 /// The 64-bit control status registers.
@@ -63,7 +63,7 @@ pub struct CSR32 {
 /// Additionally some registers are read only.
 #[derive(Debug)]
 pub struct CSR64 {
-    registers: Vec<AtomicI64>,
+    registers: Box<[AtomicI64]>,
 }
 
 macro_rules! implement_csr {
@@ -72,7 +72,9 @@ macro_rules! implement_csr {
             fn new() -> Self {
                 let mut registers = Vec::default();
                 registers.resize_with(CSR_SIZE, Default::default);
-                Self { registers }
+                Self {
+                    registers: registers.into_boxed_slice(),
+                }
             }
         }
         impl Default for $struct_name {

--- a/src/csr.rs
+++ b/src/csr.rs
@@ -1,19 +1,66 @@
 use std::sync::atomic::{AtomicI32, AtomicI64, Ordering::SeqCst};
 
+/// According to the RISC-V specification, the number of control status registers.
 const CSR_SIZE: usize = 4096;
 
+/// The control status registers.
 pub trait CSR {
     type Register;
+    /// Swaps the value for the value at `index`.
+    ///
+    /// Panics if index is out of bounds (>`CSR_SIZE`)
     fn read_write(&self, index: u16, value: Self::Register) -> Self::Register;
+    /// Set the bits in the `value` bit mask.
+    ///
+    /// Panics if index is out of bounds (>`CSR_SIZE`)
     fn set_bits(&self, index: u16, value: Self::Register) -> Self::Register;
+    /// Clears the bits in the `value` bit mask.
+    ///
+    /// Panics if index is out of bounds (>`CSR_SIZE`)
     fn clear_bits(&self, index: u16, value: Self::Register) -> Self::Register;
 }
 
+/// The 32-bit control status registers.
+///
+/// This is currently a naïve implementation which simply is a heap allocated
+/// fixed size array.
+///
+/// For example, the following instructions represent reading certain system
+/// attributes from the CSRs
+/// - `RDCYCLE[H]` - a pseudo-instruction to read the cycle CSR which holds the
+///   count of the number of clock cycles executed by the processor core on
+///   which the hart is running form an arbitrary time in the past
+/// - `RDTIME[H]` - a pseudo-instruction to read the time CSR which counts the
+///   wall-clock real time that has passed from an arbitrary start time in the
+///   past.
+/// - `RDINSTRET[H]` - a pseudo-instruction to read the instret CSR which counts
+///   the number of instructions retired by this hart from some arbitrary start
+///   point in the past.
+///
+/// Additionally some registers are read only.
 #[derive(Debug)]
 pub struct CSR32 {
     registers: Vec<AtomicI32>,
 }
 
+/// The 64-bit control status registers.
+///
+/// This is currently a naïve implementation which simply is a heap allocated
+/// fixed size array.
+///
+/// For example, the following instructions represent reading certain system
+/// attributes from the CSRs
+/// - `RDCYCLE` - a pseudo-instruction to read the cycle CSR which holds the
+///   count of the number of clock cycles executed by the processor core on
+///   which the hart is running form an arbitrary time in the past
+/// - `RDTIME` - a pseudo-instruction to read the time CSR which counts the
+///   wall-clock real time that has passed from an arbitrary start time in the
+///   past.
+/// - `RDINSTRET` - a pseudo-instruction to read the instret CSR which counts
+///   the number of instructions retired by this hart from some arbitrary start
+///   point in the past.
+///
+/// Additionally some registers are read only.
 #[derive(Debug)]
 pub struct CSR64 {
     registers: Vec<AtomicI64>,

--- a/src/instruction_set.rs
+++ b/src/instruction_set.rs
@@ -1,15 +1,19 @@
-use crate::processor::Processor;
+use crate::{csr::CSR, processor::Processor};
 
 #[derive(Debug)]
 pub enum Exception {}
 
 pub trait InstructionSet: Sized {
     type RegisterType;
+    type CSRType: CSR<Register = Self::RegisterType>;
 
     /// Decode this 32-bit value as an instruction
     fn decode(raw_instruction: u32) -> Result<Self, Exception>;
 
-    fn execute(self, processor: &mut Processor<Self::RegisterType>) -> Result<(), Exception>;
+    fn execute(
+        self,
+        processor: &mut Processor<Self::RegisterType, Self::CSRType>,
+    ) -> Result<(), Exception>;
 
     /// Returns the size of this instruction in number of bytes
     fn instruction_size(&self) -> usize {

--- a/src/instruction_set.rs
+++ b/src/instruction_set.rs
@@ -1,11 +1,11 @@
-use crate::{csr::CSR, processor::Processor};
+use crate::{csr::ControlStatusRegisters, processor::Processor};
 
 #[derive(Debug)]
 pub enum Exception {}
 
 pub trait InstructionSet: Sized {
     type RegisterType;
-    type CSRType: CSR<Register = Self::RegisterType>;
+    type CSRType: ControlStatusRegisters<Register = Self::RegisterType>;
 
     /// Decode this 32-bit value as an instruction
     fn decode(raw_instruction: u32) -> Result<Self, Exception>;

--- a/src/instructions/csr.rs
+++ b/src/instructions/csr.rs
@@ -1,0 +1,33 @@
+use std::ops::Deref;
+
+pub(super) struct CSR(u16);
+
+impl CSR {
+    const MASK: u32 = u32::from_le(0b_1111111_11111_00000_000_00000_0000000);
+    const RSHIFT: usize = 20;
+}
+
+impl From<u32> for CSR {
+    fn from(value: u32) -> Self {
+        Self(((value & Self::MASK) >> Self::RSHIFT) as u16)
+    }
+}
+
+impl Deref for CSR {
+    type Target = u16;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn from_u32() {
+        let instruction = u32::from_le(0b_1111111_11111_01100_101_11000_0110111);
+        assert_eq!(*CSR::from(instruction), 4095);
+    }
+}

--- a/src/instructions/csr.rs
+++ b/src/instructions/csr.rs
@@ -1,19 +1,19 @@
 use std::ops::Deref;
 
-pub(super) struct CSR(u16);
+pub(super) struct Csr(u16);
 
-impl CSR {
+impl Csr {
     const MASK: u32 = u32::from_le(0b_1111111_11111_00000_000_00000_0000000);
     const RSHIFT: usize = 20;
 }
 
-impl From<u32> for CSR {
+impl From<u32> for Csr {
     fn from(value: u32) -> Self {
         Self(((value & Self::MASK) >> Self::RSHIFT) as u16)
     }
 }
 
-impl Deref for CSR {
+impl Deref for Csr {
     type Target = u16;
 
     fn deref(&self) -> &Self::Target {
@@ -28,6 +28,6 @@ mod test {
     #[test]
     fn from_u32() {
         let instruction = u32::from_le(0b_1111111_11111_01100_101_11000_0110111);
-        assert_eq!(*CSR::from(instruction), 4095);
+        assert_eq!(*Csr::from(instruction), 4095);
     }
 }

--- a/src/instructions/csr_imm.rs
+++ b/src/instructions/csr_imm.rs
@@ -1,0 +1,33 @@
+use std::ops::Deref;
+
+pub(super) struct CsrImm(u8);
+
+impl CsrImm {
+    const MASK: u32 = u32::from_le(0b_0000000_00000_11111_000_00000_0000000);
+    const RSHIFT: usize = 15;
+}
+
+impl From<u32> for CsrImm {
+    fn from(value: u32) -> Self {
+        Self(((value & Self::MASK) >> Self::RSHIFT) as u8)
+    }
+}
+
+impl Deref for CsrImm {
+    type Target = u8;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn from_u32() {
+        let instruction = u32::from_le(0b_0100100_01010_01100_101_01000_0010011);
+        assert_eq!(*CsrImm::from(instruction), 12);
+    }
+}

--- a/src/instructions/impl_instruction_set.rs
+++ b/src/instructions/impl_instruction_set.rs
@@ -111,6 +111,10 @@ impl InstructionSet for Instruction {
                     .csrs
                     .read_write(csr, Self::RegisterType::from(imm))
             }
+            Instruction::CSRRSI { rd, csr, imm } => {
+                processor.registers[rd] =
+                    processor.csrs.set_bits(csr, Self::RegisterType::from(imm))
+            }
             Instruction::LB { rd, rs1, offset } => {
                 processor.registers[rd] = processor.memory.load_byte(
                     processor.registers[rs1]
@@ -1101,6 +1105,25 @@ mod test {
             Instruction::CSRRWI { rd: Register::T1, imm: 32, csr: 5 },
             changes: {registers: {t1: 3}, csr: {5: 42}},
             to: {registers: {t1: 42}, csr: {5: 32}},
+        );
+    }
+
+    #[test]
+    fn execute_csrrsi() {
+        test_execute!(
+            Instruction::CSRRSI { rd: Register::T2, imm: 12, csr: 20 },
+            changes: {registers: {t2: 3}},
+            to: {registers: {t2: 0}, csr: {20: 12}},
+        );
+        test_execute!(
+            Instruction::CSRRSI { rd: Register::S8, imm: 0, csr: 20 },
+            changes: {registers: {s8: 3}, csr: {20: 12}},
+            to: {registers: {s8: 12}, csr: {20: 12}},
+        );
+        test_execute!(
+            Instruction::CSRRSI { rd: Register::A6, imm: 0b01010, csr: 5 },
+            changes: {registers: {a6: 3}, csr: {5: 0b10000101}},
+            to: {registers: {a6: 0b10000101}, csr: {5: 0b10001111}},
         );
     }
 }

--- a/src/instructions/impl_instruction_set.rs
+++ b/src/instructions/impl_instruction_set.rs
@@ -254,10 +254,7 @@ mod test {
 
             // Assert
             let expected_state = processor_state!($final_state);
-            assert_eq!(processor.registers, expected_state.registers);
-            assert_eq!(processor.memory, expected_state.memory);
-            assert_eq!(processor.pc, expected_state.pc);
-            assert_eq!(processor.csrs, expected_state.csrs);
+            assert_eq!(processor, expected_state);
             processor
         }};
     }
@@ -273,10 +270,7 @@ mod test {
 
             // Assert
             let expected_state = processor_state!($final_state);
-            assert_eq!(processor.registers, expected_state.registers);
-            assert_eq!(processor.memory, expected_state.memory);
-            assert_eq!(processor.pc, expected_state.pc);
-            assert_eq!(processor.csrs, expected_state.csrs);
+            assert_eq!(processor, expected_state);
             processor
         }};
     }

--- a/src/instructions/impl_instruction_set.rs
+++ b/src/instructions/impl_instruction_set.rs
@@ -1164,4 +1164,18 @@ mod test {
             to: {registers: {}, csr: {42: 5}},
         );
     }
+
+    #[test]
+    fn execute_csrsi() {
+        test_execute_many!(
+            Instruction::CSRSI(42, 0),
+            changes: {registers: {}},
+            to: {registers: {}},
+        );
+        test_execute_many!(
+            Instruction::CSRSI(5, 0b10101),
+            changes: {registers: {}, csr: {5: 0b10000101}},
+            to: {registers: {}, csr: {5: 0b10010101}},
+        );
+    }
 }

--- a/src/instructions/impl_instruction_set.rs
+++ b/src/instructions/impl_instruction_set.rs
@@ -1056,4 +1056,32 @@ mod test {
             to: {registers: {tp: 0b10000101, a7: 0b10010010}, csr: {5: 0b00000101}},
         );
     }
+
+    #[test]
+    fn execute_csrs() {
+        test_execute_many!(
+            Instruction::CSRS(Register::S3, 42),
+            changes: {registers: {s3: 0}},
+            to: {registers: {s3: 0}},
+        );
+        test_execute_many!(
+            Instruction::CSRS(Register::S7, 5),
+            changes: {registers: {s7: 0b10010010}, csr: {5: 0b10000101}},
+            to: {registers: {s7: 0b10010010}, csr: {5: 0b10010111}},
+        );
+    }
+
+    #[test]
+    fn execute_csrc() {
+        test_execute_many!(
+            Instruction::CSRC(Register::S3, 42),
+            changes: {registers: {s3: 0}},
+            to: {registers: {s3: 0}},
+        );
+        test_execute_many!(
+            Instruction::CSRC(Register::SP, 5),
+            changes: {registers: {sp: 0b10010010}, csr: {5: 0b10000101}},
+            to: {registers: {sp: 0b10010010}, csr: {5: 0b00000101}},
+        );
+    }
 }

--- a/src/instructions/impl_instruction_set.rs
+++ b/src/instructions/impl_instruction_set.rs
@@ -115,6 +115,11 @@ impl InstructionSet for Instruction {
                 processor.registers[rd] =
                     processor.csrs.set_bits(csr, Self::RegisterType::from(imm))
             }
+            Instruction::CSRRCI { rd, csr, imm } => {
+                processor.registers[rd] = processor
+                    .csrs
+                    .clear_bits(csr, Self::RegisterType::from(imm))
+            }
             Instruction::LB { rd, rs1, offset } => {
                 processor.registers[rd] = processor.memory.load_byte(
                     processor.registers[rs1]
@@ -1124,6 +1129,25 @@ mod test {
             Instruction::CSRRSI { rd: Register::A6, imm: 0b01010, csr: 5 },
             changes: {registers: {a6: 3}, csr: {5: 0b10000101}},
             to: {registers: {a6: 0b10000101}, csr: {5: 0b10001111}},
+        );
+    }
+
+    #[test]
+    fn execute_csrrci() {
+        test_execute!(
+            Instruction::CSRRCI { rd: Register::RA, imm: 12, csr: 20 },
+            changes: {registers: {ra: 3}},
+            to: {registers: {ra: 0}},
+        );
+        test_execute!(
+            Instruction::CSRRSI { rd: Register::S9, imm: 0, csr: 20 },
+            changes: {registers: {s9: 30}, csr: {20: 12}},
+            to: {registers: {s9: 12}, csr: {20: 12}},
+        );
+        test_execute!(
+            Instruction::CSRRCI { rd: Register::TP, imm: 0b10101, csr: 5 },
+            changes: {registers: {tp: 3}, csr: {5: 0b10000101}},
+            to: {registers: {tp: 0b10000101}, csr: {5: 0b10000000}},
         );
     }
 }

--- a/src/instructions/impl_instruction_set.rs
+++ b/src/instructions/impl_instruction_set.rs
@@ -1013,6 +1013,20 @@ mod test {
     }
 
     #[test]
+    fn execute_csrw() {
+        test_execute_many!(
+            Instruction::CSRW(Register::S3, 42),
+            changes: {registers: {s3: 0}},
+            to: {registers: {s3: 0}},
+        );
+        test_execute_many!(
+            Instruction::CSRW(Register::S6, 42),
+            changes: {registers: {s6: 3}, csr: {42: 42}},
+            to: {registers: {s6: 3}, csr: {42: 3}},
+        );
+    }
+
+    #[test]
     fn execute_csrrs() {
         test_execute!(
             Instruction::CSRRS { rd: Register::T2, rs1: Register::S4, csr: 20 },

--- a/src/instructions/impl_instruction_set.rs
+++ b/src/instructions/impl_instruction_set.rs
@@ -98,7 +98,10 @@ impl InstructionSet for Instruction {
             }
             Instruction::CSRRS { rd, rs1, csr } => {
                 processor.registers[rd] = processor.csrs.set_bits(csr, processor.registers[rs1])
-            },
+            }
+            Instruction::CSRRC { rd, rs1, csr } => {
+                processor.registers[rd] = processor.csrs.clear_bits(csr, processor.registers[rs1])
+            }
             Instruction::LB { rd, rs1, offset } => {
                 processor.registers[rd] = processor.memory.load_byte(
                     processor.registers[rs1]
@@ -1001,6 +1004,20 @@ mod test {
             Instruction::CSRRS { rd: Register::T1, rs1: Register::T0, csr: 5 },
             changes: {registers: {t1: 3, t0: 0b10010010}, csr: {5: 0b10000101}},
             to: {registers: {t1: 0b10000101, t0: 0b10010010}, csr: {5: 0b10010111}},
+        );
+    }
+
+    #[test]
+    fn execute_csrrc() {
+        test_execute!(
+            Instruction::CSRRC { rd: Register::A0, rs1: Register::RA, csr: 20 },
+            changes: {registers: {a0: 3, ra: 12}},
+            to: {registers: {a0: 0, ra: 12}},
+        );
+        test_execute!(
+            Instruction::CSRRC { rd: Register::T1, rs1: Register::T0, csr: 5 },
+            changes: {registers: {t1: 3, t0: 0b10010010}, csr: {5: 0b10000101}},
+            to: {registers: {t1: 0b10000101, t0: 0b10010010}, csr: {5: 0b00000101}},
         );
     }
 }

--- a/src/instructions/impl_instruction_set.rs
+++ b/src/instructions/impl_instruction_set.rs
@@ -982,9 +982,9 @@ mod test {
     #[test]
     fn execute_csrrw() {
         test_execute!(
-            Instruction::CSRRW { rd: Register::A0, rs1: Register::RA, csr: 20 },
-            changes: {registers: {a0: 3, ra: 12}},
-            to: {registers: {a0: 0, ra: 12}, csr: {20: 12}},
+            Instruction::CSRRW { rd: Register::A0, rs1: Register::S10, csr: 20 },
+            changes: {registers: {a0: 3, s10: 12}},
+            to: {registers: {a0: 0, s10: 12}, csr: {20: 12}},
         );
         test_execute!(
             Instruction::CSRRW { rd: Register::T1, rs1: Register::T0, csr: 5 },
@@ -996,28 +996,28 @@ mod test {
     #[test]
     fn execute_csrrs() {
         test_execute!(
-            Instruction::CSRRS { rd: Register::A0, rs1: Register::RA, csr: 20 },
-            changes: {registers: {a0: 3, ra: 12}},
-            to: {registers: {a0: 0, ra: 12}, csr: {20: 12}},
+            Instruction::CSRRS { rd: Register::T2, rs1: Register::S4, csr: 20 },
+            changes: {registers: {t2: 3, s4: 12}},
+            to: {registers: {t2: 0, s4: 12}, csr: {20: 12}},
         );
         test_execute!(
-            Instruction::CSRRS { rd: Register::T1, rs1: Register::T0, csr: 5 },
-            changes: {registers: {t1: 3, t0: 0b10010010}, csr: {5: 0b10000101}},
-            to: {registers: {t1: 0b10000101, t0: 0b10010010}, csr: {5: 0b10010111}},
+            Instruction::CSRRS { rd: Register::A6, rs1: Register::S7, csr: 5 },
+            changes: {registers: {a6: 3, s7: 0b10010010}, csr: {5: 0b10000101}},
+            to: {registers: {a6: 0b10000101, s7: 0b10010010}, csr: {5: 0b10010111}},
         );
     }
 
     #[test]
     fn execute_csrrc() {
         test_execute!(
-            Instruction::CSRRC { rd: Register::A0, rs1: Register::RA, csr: 20 },
-            changes: {registers: {a0: 3, ra: 12}},
-            to: {registers: {a0: 0, ra: 12}},
+            Instruction::CSRRC { rd: Register::RA, rs1: Register::GP, csr: 20 },
+            changes: {registers: {ra: 3, gp: 12}},
+            to: {registers: {ra: 0, gp: 12}},
         );
         test_execute!(
-            Instruction::CSRRC { rd: Register::T1, rs1: Register::T0, csr: 5 },
-            changes: {registers: {t1: 3, t0: 0b10010010}, csr: {5: 0b10000101}},
-            to: {registers: {t1: 0b10000101, t0: 0b10010010}, csr: {5: 0b00000101}},
+            Instruction::CSRRC { rd: Register::TP, rs1: Register::A7, csr: 5 },
+            changes: {registers: {tp: 3, a7: 0b10010010}, csr: {5: 0b10000101}},
+            to: {registers: {tp: 0b10000101, a7: 0b10010010}, csr: {5: 0b00000101}},
         );
     }
 }

--- a/src/instructions/impl_instruction_set.rs
+++ b/src/instructions/impl_instruction_set.rs
@@ -1,4 +1,4 @@
-use crate::csr::{CSR, CSR32};
+use crate::csr::{ControlStatusRegisters, CSR32};
 use crate::instruction_set::{Exception, InstructionSet};
 use crate::integer::{AsSigned, AsUnsigned};
 use crate::processor::Processor;

--- a/src/instructions/impl_instruction_set.rs
+++ b/src/instructions/impl_instruction_set.rs
@@ -22,9 +22,7 @@ impl InstructionSet for Instruction {
     ) -> Result<(), Exception> {
         match self {
             Instruction::LUI { rd, imm } => processor.registers[rd] = imm << 12,
-            Instruction::AUIPC { rd, imm } => {
-                processor.registers[rd] = processor.pc + Self::RegisterType::from(imm << 12)
-            }
+            Instruction::AUIPC { rd, imm } => processor.registers[rd] = processor.pc + (imm << 12),
             Instruction::ADDI { rd, rs1, imm } => {
                 processor.registers[rd] = processor.registers[rs1].wrapping_add(imm.into())
             }

--- a/src/instructions/impl_instruction_set.rs
+++ b/src/instructions/impl_instruction_set.rs
@@ -1178,4 +1178,18 @@ mod test {
             to: {registers: {}, csr: {5: 0b10010101}},
         );
     }
+
+    #[test]
+    fn execute_csrci() {
+        test_execute_many!(
+            Instruction::CSRCI(42, 0),
+            changes: {registers: {}},
+            to: {registers: {}},
+        );
+        test_execute_many!(
+            Instruction::CSRCI(5, 0b10011),
+            changes: {registers: {}, csr: {5: 0b10000101}},
+            to: {registers: {}, csr: {5: 0b10000100}},
+        );
+    }
 }

--- a/src/instructions/impl_instruction_set.rs
+++ b/src/instructions/impl_instruction_set.rs
@@ -1150,4 +1150,18 @@ mod test {
             to: {registers: {tp: 0b10000101}, csr: {5: 0b10000000}},
         );
     }
+
+    #[test]
+    fn execute_csrwi() {
+        test_execute_many!(
+            Instruction::CSRWI(42, 0),
+            changes: {registers: {}},
+            to: {registers: {}},
+        );
+        test_execute_many!(
+            Instruction::CSRWI(42, 5),
+            changes: {registers: {}, csr: {42: 42}},
+            to: {registers: {}, csr: {42: 5}},
+        );
+    }
 }

--- a/src/instructions/impl_instruction_set.rs
+++ b/src/instructions/impl_instruction_set.rs
@@ -106,6 +106,11 @@ impl InstructionSet for Instruction {
             Instruction::CSRRC { rd, rs1, csr } => {
                 processor.registers[rd] = processor.csrs.clear_bits(csr, processor.registers[rs1])
             }
+            Instruction::CSRRWI { rd, csr, imm } => {
+                processor.registers[rd] = processor
+                    .csrs
+                    .read_write(csr, Self::RegisterType::from(imm))
+            }
             Instruction::LB { rd, rs1, offset } => {
                 processor.registers[rd] = processor.memory.load_byte(
                     processor.registers[rs1]
@@ -1082,6 +1087,20 @@ mod test {
             Instruction::CSRC(Register::SP, 5),
             changes: {registers: {sp: 0b10010010}, csr: {5: 0b10000101}},
             to: {registers: {sp: 0b10010010}, csr: {5: 0b00000101}},
+        );
+    }
+
+    #[test]
+    fn execute_csrrwi() {
+        test_execute!(
+            Instruction::CSRRWI { rd: Register::A0, imm: 12, csr: 20 },
+            changes: {registers: {a0: 3}},
+            to: {registers: {a0: 0}, csr: {20: 12}},
+        );
+        test_execute!(
+            Instruction::CSRRWI { rd: Register::T1, imm: 32, csr: 5 },
+            changes: {registers: {t1: 3}, csr: {5: 42}},
+            to: {registers: {t1: 42}, csr: {5: 32}},
         );
     }
 }

--- a/src/instructions/impl_instruction_set.rs
+++ b/src/instructions/impl_instruction_set.rs
@@ -94,13 +94,14 @@ impl InstructionSet for Instruction {
             Instruction::AND { rd, rs1, rs2 } => {
                 processor.registers[rd] = processor.registers[rs1] & processor.registers[rs2]
             }
-            Instruction::CSRRW { rd, rs1, csr } => match rs1 {
-                Register::ZERO => processor.registers[rd] = processor.csrs.read(csr),
-                _ => {
-                    processor.registers[rd] =
-                        processor.csrs.read_write(csr, processor.registers[rs1])
-                }
-            },
+            Instruction::CSRRW {
+                rd,
+                rs1: Register::ZERO,
+                csr,
+            } => processor.registers[rd] = processor.csrs.read(csr),
+            Instruction::CSRRW { rd, rs1, csr } => {
+                processor.registers[rd] = processor.csrs.read_write(csr, processor.registers[rs1])
+            }
             Instruction::CSRRS { rd, rs1, csr } => {
                 processor.registers[rd] = processor.csrs.set_bits(csr, processor.registers[rs1])
             }

--- a/src/instructions/mod.rs
+++ b/src/instructions/mod.rs
@@ -426,6 +426,14 @@ pub(super) enum Instruction {
     ///
     /// `rd = CSRs[csr]; CSRs[csr] = zext(imm)`
     CSRRWI { rd: Register, csr: u16, imm: u8 },
+
+    /// # Atomic CSR read set immediate
+    ///
+    /// Set CSR bit using an XLEN-bit value obtained by zero-extending a 5-bit
+    /// unsigned immediate (uimm[4:0]) field encoded in the rs1 field.
+    ///
+    /// `t = CSRs[csr]; CSRs[csr] = t | zext(imm); rd = t`
+    CSRRSI { rd: Register, csr: u16, imm: u8 },
 }
 
 impl From<u32> for Instruction {
@@ -621,6 +629,11 @@ impl From<u32> for Instruction {
                     csr: *CSR::from(value),
                 },
                 0b_101 => Instruction::CSRRWI {
+                    rd: *Rd::from(value),
+                    imm: *CsrImm::from(value),
+                    csr: *Csr::from(value),
+                },
+                0b_110 => Instruction::CSRRSI {
                     rd: *Rd::from(value),
                     imm: *CsrImm::from(value),
                     csr: *Csr::from(value),
@@ -1040,6 +1053,18 @@ mod test {
                 rd: Register::S5,
                 imm: 9,
                 csr: 59,
+            }
+        );
+    }
+
+    #[test]
+    fn csrrsi_from_i32() {
+        assert_eq!(
+            Instruction::from(u32::from_le(0b_0000001_01010_11011_110_10100_1110011)),
+            Instruction::CSRRSI {
+                rd: Register::S4,
+                imm: 27,
+                csr: 42,
             }
         );
     }

--- a/src/instructions/mod.rs
+++ b/src/instructions/mod.rs
@@ -15,7 +15,7 @@ mod shamt;
 mod simmi;
 
 use self::{
-    csr::CSR, csr_imm::CsrImm, funct3::Funct3, funct6::Funct6, funct7::Funct7, immi::ImmI,
+    csr::Csr, csr_imm::CsrImm, funct3::Funct3, funct6::Funct6, funct7::Funct7, immi::ImmI,
     immu::ImmU, rd::Rd, rs1::Rs1, rs2::Rs2, shamt::Shamt, simmi::SImmI,
 };
 
@@ -624,17 +624,17 @@ impl From<u32> for Instruction {
                 0b_001 => Instruction::CSRRW {
                     rd: *Rd::from(value),
                     rs1: *Rs1::from(value),
-                    csr: *CSR::from(value),
+                    csr: *Csr::from(value),
                 },
                 0b_010 => Instruction::CSRRS {
                     rd: *Rd::from(value),
                     rs1: *Rs1::from(value),
-                    csr: *CSR::from(value),
+                    csr: *Csr::from(value),
                 },
                 0b_011 => Instruction::CSRRC {
                     rd: *Rd::from(value),
                     rs1: *Rs1::from(value),
-                    csr: *CSR::from(value),
+                    csr: *Csr::from(value),
                 },
                 0b_101 => Instruction::CSRRWI {
                     rd: *Rd::from(value),

--- a/src/instructions/mod.rs
+++ b/src/instructions/mod.rs
@@ -387,7 +387,7 @@ pub(super) enum Instruction {
         csr: u16,
     },
 
-    /// # Atomic CSR read write
+    /// # Atomic CSR read set
     ///
     /// Reads the value of the CSR, zero-extends the value to XLEN bits, and
     /// writes it to integer register rd. The initial value in integer register
@@ -403,7 +403,7 @@ pub(super) enum Instruction {
         csr: u16,
     },
 
-    /// # Atomic CSR read write
+    /// # Atomic CSR read clear
     ///
     /// Reads the value of the CSR, zero-extends the value to XLEN bits, and
     /// writes it to integer register rd. The initial value in integer register

--- a/src/instructions/mod.rs
+++ b/src/instructions/mod.rs
@@ -434,6 +434,14 @@ pub(super) enum Instruction {
     ///
     /// `t = CSRs[csr]; CSRs[csr] = t | zext(imm); rd = t`
     CSRRSI { rd: Register, csr: u16, imm: u8 },
+
+    /// # Atomic CSR read clear immediate
+    ///
+    /// Clear CSR bit using an XLEN-bit value obtained by zero-extending a
+    /// 5-bit unsigned immediate (uimm[4:0]) field encoded in the rs1 field.
+    ///
+    /// `t = CSRs[csr]; CSRs[csr] = t & ~zext(imm); rd = t`
+    CSRRCI { rd: Register, csr: u16, imm: u8 },
 }
 
 impl From<u32> for Instruction {
@@ -634,6 +642,11 @@ impl From<u32> for Instruction {
                     csr: *Csr::from(value),
                 },
                 0b_110 => Instruction::CSRRSI {
+                    rd: *Rd::from(value),
+                    imm: *CsrImm::from(value),
+                    csr: *Csr::from(value),
+                },
+                0b_111 => Instruction::CSRRCI {
                     rd: *Rd::from(value),
                     imm: *CsrImm::from(value),
                     csr: *Csr::from(value),
@@ -1065,6 +1078,18 @@ mod test {
                 rd: Register::S4,
                 imm: 27,
                 csr: 42,
+            }
+        );
+    }
+
+    #[test]
+    fn csrrci_from_i32() {
+        assert_eq!(
+            Instruction::from(u32::from_le(0b_0000011_11011_11001_111_10001_1110011)),
+            Instruction::CSRRCI {
+                rd: Register::A7,
+                imm: 25,
+                csr: 123,
             }
         );
     }

--- a/src/instructions/mod.rs
+++ b/src/instructions/mod.rs
@@ -341,7 +341,7 @@ pub(super) enum Instruction {
     ///
     /// Store 8-bit, values from the low bits of register rs2 to memory.
     ///
-    /// M[rs1 + sext(offset)] = rs2[7:0]
+    /// `M[rs1 + sext(offset)] = rs2[7:0]`
     SB {
         rs1: Register,
         rs2: Register,
@@ -352,7 +352,7 @@ pub(super) enum Instruction {
     ///
     /// Store 16-bit, values from the low bits of register rs2 to memory.
     ///
-    /// M[rs1 + sext(offset)] = rs2[15:0]
+    /// `M[rs1 + sext(offset)] = rs2[15:0]`
     SH {
         rs1: Register,
         rs2: Register,
@@ -363,7 +363,7 @@ pub(super) enum Instruction {
     ///
     /// Store 32-bit, values from the low bits of register rs2 to memory.
     ///
-    /// M[rs1 + sext(offset)] = rs2[31:0]
+    /// `M[rs1 + sext(offset)] = rs2[31:0]`
     SW {
         rs1: Register,
         rs2: Register,

--- a/src/instructions/pseudoinstructions.rs
+++ b/src/instructions/pseudoinstructions.rs
@@ -286,4 +286,86 @@ mod test {
         assert!(!is_positive_i12(neg_1));
         assert!(is_positive_i12(max_i12));
     }
+
+    #[test]
+    fn iter_test() {
+        let pseudoinstruction = PseudoinstructionMappingIter::Three(
+            Instruction::ADD {
+                rd: Register::SP,
+                rs1: Register::A0,
+                rs2: Register::A2,
+            },
+            Instruction::SUB {
+                rd: Register::SP,
+                rs1: Register::A0,
+                rs2: Register::A1,
+            },
+            Instruction::OR {
+                rd: Register::SP,
+                rs1: Register::A0,
+                rs2: Register::A1,
+            },
+        );
+        assert_eq!(
+            pseudoinstruction.collect::<Vec<_>>(),
+            vec![
+                Instruction::ADD {
+                    rd: Register::SP,
+                    rs1: Register::A0,
+                    rs2: Register::A2,
+                },
+                Instruction::SUB {
+                    rd: Register::SP,
+                    rs1: Register::A0,
+                    rs2: Register::A1,
+                },
+                Instruction::OR {
+                    rd: Register::SP,
+                    rs1: Register::A0,
+                    rs2: Register::A1,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn rev_iter_test() {
+        let pseudoinstruction = PseudoinstructionMappingIter::Three(
+            Instruction::ADD {
+                rd: Register::SP,
+                rs1: Register::A0,
+                rs2: Register::A2,
+            },
+            Instruction::SUB {
+                rd: Register::SP,
+                rs1: Register::A0,
+                rs2: Register::A1,
+            },
+            Instruction::OR {
+                rd: Register::SP,
+                rs1: Register::A0,
+                rs2: Register::A1,
+            },
+        );
+        assert_eq!(
+            pseudoinstruction.rev().collect::<Vec<_>>(),
+            vec![
+                Instruction::OR {
+                    rd: Register::SP,
+                    rs1: Register::A0,
+                    rs2: Register::A1,
+                },
+                Instruction::SUB {
+                    rd: Register::SP,
+                    rs1: Register::A0,
+                    rs2: Register::A1,
+                },
+                Instruction::ADD {
+                    rd: Register::SP,
+                    rs1: Register::A0,
+                    rs2: Register::A2,
+                },
+            ]
+        );
+    }
 }

--- a/src/instructions/pseudoinstructions.rs
+++ b/src/instructions/pseudoinstructions.rs
@@ -309,6 +309,23 @@ impl Instruction {
             csr,
         })
     }
+
+    /// # Clear bits in CSR, immediate
+    ///
+    /// Clears bits in CSR using the immediate value. This instruction should
+    /// not cause any read side affects.
+    ///
+    /// Note: This pseudoinstruction desugars to `CSRRCI x0, csr, imm`
+    /// See
+    /// [ref](https://github.com/riscv-non-isa/riscv-asm-manual/blob/master/riscv-asm.md#pseudoinstructions-for-accessing-control-and-status-registers)
+    #[allow(non_snake_case)]
+    pub(crate) fn CSRCI(csr: u16, imm: u8) -> PseudoinstructionMappingIter {
+        PseudoinstructionMappingIter::One(Instruction::CSRRCI {
+            rd: Register::ZERO,
+            imm,
+            csr,
+        })
+    }
 }
 
 fn sign_extend_i12(value: i32) -> i16 {

--- a/src/instructions/pseudoinstructions.rs
+++ b/src/instructions/pseudoinstructions.rs
@@ -243,6 +243,38 @@ impl Instruction {
             csr,
         })
     }
+
+    /// # CSRS
+    ///
+    /// Sets the bits in CSR, no read side affects should be caused by this instruction.
+    ///
+    /// Note: This pseudoinstruction desugars to `CSRRS x0, csr, rs`
+    /// See
+    /// [ref](https://github.com/riscv-non-isa/riscv-asm-manual/blob/master/riscv-asm.md#pseudoinstructions-for-accessing-control-and-status-registers)
+    #[allow(non_snake_case)]
+    pub(crate) fn CSRS(rs1: Register, csr: u16) -> PseudoinstructionMappingIter {
+        PseudoinstructionMappingIter::One(Instruction::CSRRS {
+            rd: Register::ZERO,
+            rs1,
+            csr,
+        })
+    }
+
+    /// # CSRC
+    ///
+    /// Read CSR
+    ///
+    /// Note: This pseudoinstruction desugars to `CSRRC x0, csr, rs`
+    /// See
+    /// [ref](https://github.com/riscv-non-isa/riscv-asm-manual/blob/master/riscv-asm.md#pseudoinstructions-for-accessing-control-and-status-registers)
+    #[allow(non_snake_case)]
+    pub(crate) fn CSRC(rs1: Register, csr: u16) -> PseudoinstructionMappingIter {
+        PseudoinstructionMappingIter::One(Instruction::CSRRC {
+            rd: Register::ZERO,
+            rs1,
+            csr,
+        })
+    }
 }
 
 fn sign_extend_i12(value: i32) -> i16 {

--- a/src/instructions/pseudoinstructions.rs
+++ b/src/instructions/pseudoinstructions.rs
@@ -275,6 +275,23 @@ impl Instruction {
             csr,
         })
     }
+
+    /// # Write CSR, immediate
+    ///
+    /// Writes into CSR, using the immediate value. This instruction should
+    /// not cause any read side affects.
+    ///
+    /// Note: This pseudoinstruction desugars to `CSRRWI x0, csr, imm`
+    /// See
+    /// [ref](https://github.com/riscv-non-isa/riscv-asm-manual/blob/master/riscv-asm.md#pseudoinstructions-for-accessing-control-and-status-registers)
+    #[allow(non_snake_case)]
+    pub(crate) fn CSRWI(csr: u16, imm: u8) -> PseudoinstructionMappingIter {
+        PseudoinstructionMappingIter::One(Instruction::CSRRWI {
+            rd: Register::ZERO,
+            imm,
+            csr,
+        })
+    }
 }
 
 fn sign_extend_i12(value: i32) -> i16 {

--- a/src/instructions/pseudoinstructions.rs
+++ b/src/instructions/pseudoinstructions.rs
@@ -292,6 +292,23 @@ impl Instruction {
             csr,
         })
     }
+
+    /// # Set bits in CSR, immediate
+    ///
+    /// Sets bits in CSR using the immediate value. This instruction should
+    /// not cause any read side affects.
+    ///
+    /// Note: This pseudoinstruction desugars to `CSRRSI x0, csr, imm`
+    /// See
+    /// [ref](https://github.com/riscv-non-isa/riscv-asm-manual/blob/master/riscv-asm.md#pseudoinstructions-for-accessing-control-and-status-registers)
+    #[allow(non_snake_case)]
+    pub(crate) fn CSRSI(csr: u16, imm: u8) -> PseudoinstructionMappingIter {
+        PseudoinstructionMappingIter::One(Instruction::CSRRSI {
+            rd: Register::ZERO,
+            imm,
+            csr,
+        })
+    }
 }
 
 fn sign_extend_i12(value: i32) -> i16 {

--- a/src/instructions/pseudoinstructions.rs
+++ b/src/instructions/pseudoinstructions.rs
@@ -211,6 +211,38 @@ impl Instruction {
             rs1: Register::ZERO,
             imm: 0,
         });
+
+    /// # CSRR
+    ///
+    /// Read CSR
+    ///
+    /// Note: This pseudoinstruction desugars to `CSRRW rd, csr, x0`
+    /// See
+    /// [ref](https://github.com/riscv-non-isa/riscv-asm-manual/blob/master/riscv-asm.md#pseudoinstructions-for-accessing-control-and-status-registers)
+    #[allow(non_snake_case)]
+    pub(crate) fn CSRR(rd: Register, csr: u16) -> PseudoinstructionMappingIter {
+        PseudoinstructionMappingIter::One(Instruction::CSRRW {
+            rd,
+            rs1: Register::ZERO,
+            csr,
+        })
+    }
+
+    /// # CSRW
+    ///
+    /// Write CSR, no read side affects should be caused by this instruction.
+    ///
+    /// Note: This pseudoinstruction desugars to `CSRRW x0, csr, rs`
+    /// See
+    /// [ref](https://github.com/riscv-non-isa/riscv-asm-manual/blob/master/riscv-asm.md#pseudoinstructions-for-accessing-control-and-status-registers)
+    #[allow(non_snake_case)]
+    pub(crate) fn CSRW(rs1: Register, csr: u16) -> PseudoinstructionMappingIter {
+        PseudoinstructionMappingIter::One(Instruction::CSRRW {
+            rd: Register::ZERO,
+            rs1,
+            csr,
+        })
+    }
 }
 
 fn sign_extend_i12(value: i32) -> i16 {

--- a/src/instructions/pseudoinstructions.rs
+++ b/src/instructions/pseudoinstructions.rs
@@ -212,7 +212,7 @@ impl Instruction {
             imm: 0,
         });
 
-    /// # CSRR
+    /// # Read CSR
     ///
     /// Read CSR
     ///
@@ -228,7 +228,7 @@ impl Instruction {
         })
     }
 
-    /// # CSRW
+    /// # Write CSR
     ///
     /// Write CSR, no read side affects should be caused by this instruction.
     ///
@@ -244,9 +244,10 @@ impl Instruction {
         })
     }
 
-    /// # CSRS
+    /// # Set bits in CSR
     ///
-    /// Sets the bits in CSR, no read side affects should be caused by this instruction.
+    /// Sets the bits in CSR, no read side affects should be caused by this
+    /// instruction.
     ///
     /// Note: This pseudoinstruction desugars to `CSRRS x0, csr, rs`
     /// See
@@ -260,9 +261,10 @@ impl Instruction {
         })
     }
 
-    /// # CSRC
+    /// # Clear bits in CSR
     ///
-    /// Read CSR
+    /// Clear bits in CSR, no read side affects should be caused by this
+    /// instruction.
     ///
     /// Note: This pseudoinstruction desugars to `CSRRC x0, csr, rs`
     /// See

--- a/src/instructions/pseudoinstructions.rs
+++ b/src/instructions/pseudoinstructions.rs
@@ -230,7 +230,7 @@ impl Instruction {
 
     /// # Write CSR
     ///
-    /// Write CSR, no read side affects should be caused by this instruction.
+    /// Write CSR, no read side effects should be caused by this instruction.
     ///
     /// Note: This pseudoinstruction desugars to `CSRRW x0, csr, rs`
     /// See
@@ -246,7 +246,7 @@ impl Instruction {
 
     /// # Set bits in CSR
     ///
-    /// Sets the bits in CSR, no read side affects should be caused by this
+    /// Sets the bits in CSR, no read side effects should be caused by this
     /// instruction.
     ///
     /// Note: This pseudoinstruction desugars to `CSRRS x0, csr, rs`
@@ -263,7 +263,7 @@ impl Instruction {
 
     /// # Clear bits in CSR
     ///
-    /// Clear bits in CSR, no read side affects should be caused by this
+    /// Clear bits in CSR, no read side effects should be caused by this
     /// instruction.
     ///
     /// Note: This pseudoinstruction desugars to `CSRRC x0, csr, rs`
@@ -281,7 +281,7 @@ impl Instruction {
     /// # Write CSR, immediate
     ///
     /// Writes into CSR, using the immediate value. This instruction should
-    /// not cause any read side affects.
+    /// not cause any read side effects.
     ///
     /// Note: This pseudoinstruction desugars to `CSRRWI x0, csr, imm`
     /// See
@@ -298,7 +298,7 @@ impl Instruction {
     /// # Set bits in CSR, immediate
     ///
     /// Sets bits in CSR using the immediate value. This instruction should
-    /// not cause any read side affects.
+    /// not cause any read side effects.
     ///
     /// Note: This pseudoinstruction desugars to `CSRRSI x0, csr, imm`
     /// See
@@ -315,7 +315,7 @@ impl Instruction {
     /// # Clear bits in CSR, immediate
     ///
     /// Clears bits in CSR using the immediate value. This instruction should
-    /// not cause any read side affects.
+    /// not cause any read side effects.
     ///
     /// Note: This pseudoinstruction desugars to `CSRRCI x0, csr, imm`
     /// See

--- a/src/integer.rs
+++ b/src/integer.rs
@@ -4,33 +4,33 @@ pub(crate) mod i12 {
 }
 
 pub(crate) trait AsUnsigned<N> {
-    fn as_unsigned(self) -> N;
+    fn as_unsigned(&self) -> N;
 }
 
 pub(crate) trait AsSigned<N> {
-    fn as_signed(self) -> N;
+    fn as_signed(&self) -> N;
 }
 
 macro_rules! impl_signed_unsigned {
     ($signed:ty, $unsigned:ty) => {
         impl AsUnsigned<$unsigned> for $signed {
-            fn as_unsigned(self) -> $unsigned {
-                self as $unsigned
+            fn as_unsigned(&self) -> $unsigned {
+                *self as $unsigned
             }
         }
         impl AsUnsigned<$unsigned> for $unsigned {
-            fn as_unsigned(self) -> $unsigned {
-                self as $unsigned
+            fn as_unsigned(&self) -> $unsigned {
+                *self as $unsigned
             }
         }
         impl AsSigned<$signed> for $signed {
-            fn as_signed(self) -> $signed {
-                self as $signed
+            fn as_signed(&self) -> $signed {
+                *self as $signed
             }
         }
         impl AsSigned<$signed> for $unsigned {
-            fn as_signed(self) -> $signed {
-                self as $signed
+            fn as_signed(&self) -> $signed {
+                *self as $signed
             }
         }
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+mod csr;
 pub mod instruction_set;
 mod instructions;
 mod integer;

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -1,10 +1,12 @@
+use crate::csr::CSR;
 use crate::memory::Memory;
 use crate::registers::Registers;
 
 #[derive(Debug, Default, PartialEq, Eq)]
-pub struct Processor<R> {
+pub struct Processor<R, CSRs: CSR<Register = R>> {
     pub(crate) registers: Registers<R>,
     // Programme Counter
     pub(crate) pc: R,
+    pub(crate) csrs: CSRs,
     pub(crate) memory: Memory,
 }

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -1,9 +1,9 @@
-use crate::csr::CSR;
+use crate::csr::ControlStatusRegisters;
 use crate::memory::Memory;
 use crate::registers::Registers;
 
 #[derive(Debug, Default, PartialEq, Eq)]
-pub struct Processor<R, CSRs: CSR<Register = R>> {
+pub struct Processor<R, CSRs: ControlStatusRegisters<Register = R>> {
     pub(crate) registers: Registers<R>,
     // Programme Counter
     pub(crate) pc: R,

--- a/src/registers.rs
+++ b/src/registers.rs
@@ -1,3 +1,8 @@
+use std::{
+    fmt::Debug,
+    ops::{Deref, DerefMut},
+};
+
 /// Struct representing the RISK-V Processor.
 ///
 /// The processor contains the following registers.
@@ -38,10 +43,7 @@
 /// | 31 | -   | x31      | t6       | temporary register 6                 | caller   |
 #[derive(Debug, Default, PartialEq, Eq)]
 pub(super) struct Registers<T> {
-    pub(super) zero: T,
-    // Since zero is hard wired, we don't want to give out a mutable reference,
-    // this is a compromise until I think of a better way to do this.
-    pub(super) _zero: T,
+    pub(super) zero: ZeroRegister<T>,
     pub(super) ra: T,
     pub(super) sp: T,
     pub(super) gp: T,
@@ -73,6 +75,42 @@ pub(super) struct Registers<T> {
     pub(super) t4: T,
     pub(super) t5: T,
     pub(super) t6: T,
+}
+
+#[derive(Default)]
+pub(super) struct ZeroRegister<T> {
+    zero: T,
+    // Since zero is hard wired, we don't want to give out a mutable reference,
+    // this is a compromise until I think of a better way to do this.
+    _zero: T,
+}
+
+impl<T> Debug for ZeroRegister<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("0")
+    }
+}
+
+impl<T> PartialEq for ZeroRegister<T> {
+    fn eq(&self, _other: &Self) -> bool {
+        true
+    }
+}
+
+impl<T> Eq for ZeroRegister<T> {}
+
+impl<T> Deref for ZeroRegister<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.zero
+    }
+}
+
+impl<T> DerefMut for ZeroRegister<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self._zero
+    }
 }
 
 #[repr(u8)]
@@ -271,7 +309,7 @@ impl<T> std::ops::Index<Register> for Registers<T> {
 impl<T> std::ops::IndexMut<u8> for Registers<T> {
     fn index_mut(&mut self, index: u8) -> &mut Self::Output {
         match index {
-            0 => &mut self._zero,
+            0 => &mut self.zero,
             1 => &mut self.ra,
             2 => &mut self.sp,
             3 => &mut self.gp,
@@ -311,7 +349,7 @@ impl<T> std::ops::IndexMut<u8> for Registers<T> {
 impl<T> std::ops::IndexMut<Register> for Registers<T> {
     fn index_mut(&mut self, index: Register) -> &mut Self::Output {
         match index {
-            Register::ZERO => &mut self._zero,
+            Register::ZERO => &mut self.zero,
             Register::RA => &mut self.ra,
             Register::SP => &mut self.sp,
             Register::GP => &mut self.gp,

--- a/src/registers.rs
+++ b/src/registers.rs
@@ -356,4 +356,17 @@ mod test {
         assert_eq!(Register::from(31), Register::T6);
         assert_eq!(Register::from(32), Register::ZERO);
     }
+
+    #[test]
+    fn register_zero_deref() {
+        let register_zero = ZeroRegister::<i32>::default();
+        assert_eq!(*register_zero, 0);
+    }
+
+    #[test]
+    fn register_zero_deref_mut() {
+        let mut register_zero = ZeroRegister::<i32>::default();
+        *register_zero = 23;
+        assert_eq!(*register_zero, 0);
+    }
 }

--- a/src/registers.rs
+++ b/src/registers.rs
@@ -107,8 +107,12 @@ impl<T> Deref for ZeroRegister<T> {
     }
 }
 
-impl<T> DerefMut for ZeroRegister<T> {
+impl<T> DerefMut for ZeroRegister<T>
+where
+    T: Default,
+{
     fn deref_mut(&mut self) -> &mut Self::Target {
+        self._zero = T::default();
         &mut self._zero
     }
 }
@@ -306,7 +310,10 @@ impl<T> std::ops::Index<Register> for Registers<T> {
     }
 }
 
-impl<T> std::ops::IndexMut<u8> for Registers<T> {
+impl<T> std::ops::IndexMut<u8> for Registers<T>
+where
+    T: Default,
+{
     fn index_mut(&mut self, index: u8) -> &mut Self::Output {
         match index {
             0 => &mut self.zero,
@@ -346,7 +353,10 @@ impl<T> std::ops::IndexMut<u8> for Registers<T> {
     }
 }
 
-impl<T> std::ops::IndexMut<Register> for Registers<T> {
+impl<T> std::ops::IndexMut<Register> for Registers<T>
+where
+    T: Default,
+{
     fn index_mut(&mut self, index: Register) -> &mut Self::Output {
         match index {
             Register::ZERO => &mut self.zero,
@@ -406,6 +416,13 @@ mod test {
         let mut register_zero = ZeroRegister::<i32>::default();
         *register_zero = 23;
         assert_eq!(*register_zero, 0);
+    }
+
+    #[test]
+    fn register_zero_deref_mut_twice() {
+        let mut register_zero = ZeroRegister::<i32>::default();
+        *register_zero = 23;
+        assert_eq!(register_zero.deref_mut(), &mut 0);
     }
 
     #[test]

--- a/src/registers.rs
+++ b/src/registers.rs
@@ -407,4 +407,40 @@ mod test {
         *register_zero = 23;
         assert_eq!(*register_zero, 0);
     }
+
+    #[test]
+    fn registers_zero_register() {
+        let registers = Registers::<i64>::default();
+        assert_eq!(registers[Register::ZERO], 0);
+    }
+
+    #[test]
+    fn registers_zero_register_mut() {
+        let mut registers = Registers::default();
+        registers[Register::ZERO] = 42;
+        assert_eq!(registers[Register::ZERO], 0);
+    }
+
+    #[test]
+    fn index_u8() {
+        let mut registers = Registers::default();
+        for i in 0..32 {
+            registers[i] = i;
+            assert_eq!(i, registers[i]);
+        }
+    }
+
+    #[test]
+    #[should_panic]
+    fn index_out_of_bounds_mut() {
+        let mut registers = Registers::default();
+        registers[32] = 32;
+    }
+
+    #[test]
+    #[should_panic]
+    fn index_out_of_bounds() {
+        let registers = Registers::<i128>::default();
+        let _ = registers[32] == 0;
+    }
 }


### PR DESCRIPTION
This PR adds initial support for the control and status register instructions.

TODO:
- [x] Add CSR structs and triats
- [x] Implement CSRRW
- [x] Implement CSRRS
- [x] Implement CSRRC
- [x] Implement CSRRWI
- [x] Implement CSRRSI
- [x] Implement CSRRCI
- [x] Implement psuedo instructions associated with CSR
