### PR TITLE
Make decode function const

### DIFF
--- a/src/instruction_set.rs
+++ b/src/instruction_set.rs
@@ -1,7 +1,22 @@
+use std::fmt::Display;
+
 use crate::{csr::ControlStatusRegisters, processor::Processor};
 
 #[derive(Debug)]
-pub enum Exception {}
+pub enum Exception {
+    UnimplementedInstruction(u32),
+}
+
+impl Display for Exception {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::UnimplementedInstruction(instuction) => f.write_fmt(format_args!(
+                "The given instruction is not yet implemented {:#034b}",
+                instuction.to_le()
+            )),
+        }
+    }
+}
 
 pub trait InstructionSet: Sized {
     type RegisterType;

--- a/src/instructions/csr.rs
+++ b/src/instructions/csr.rs
@@ -1,23 +1,12 @@
-use std::ops::Deref;
-
-pub(super) struct Csr(u16);
+pub(super) struct Csr;
 
 impl Csr {
     const MASK: u32 = u32::from_le(0b_1111111_11111_00000_000_00000_0000000);
     const RSHIFT: usize = 20;
-}
 
-impl From<u32> for Csr {
-    fn from(value: u32) -> Self {
-        Self(((value & Self::MASK) >> Self::RSHIFT) as u16)
-    }
-}
-
-impl Deref for Csr {
-    type Target = u16;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
+    #[inline]
+    pub(super) const fn decode(value: u32) -> u16 {
+        ((value & Self::MASK) >> Self::RSHIFT) as u16
     }
 }
 
@@ -27,8 +16,8 @@ mod test {
     use pretty_assertions::assert_eq;
 
     #[test]
-    fn from_u32() {
+    fn decode_u32() {
         let instruction = u32::from_le(0b_1111111_11111_01100_101_11000_0110111);
-        assert_eq!(*Csr::from(instruction), 4095);
+        assert_eq!(Csr::decode(instruction), 4095);
     }
 }

--- a/src/instructions/csr_imm.rs
+++ b/src/instructions/csr_imm.rs
@@ -1,23 +1,12 @@
-use std::ops::Deref;
-
-pub(super) struct CsrImm(u8);
+pub(super) struct CsrImm;
 
 impl CsrImm {
     const MASK: u32 = u32::from_le(0b_0000000_00000_11111_000_00000_0000000);
     const RSHIFT: usize = 15;
-}
 
-impl From<u32> for CsrImm {
-    fn from(value: u32) -> Self {
-        Self(((value & Self::MASK) >> Self::RSHIFT) as u8)
-    }
-}
-
-impl Deref for CsrImm {
-    type Target = u8;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
+    #[inline]
+    pub(super) const fn decode(value: u32) -> u8 {
+        ((value & Self::MASK) >> Self::RSHIFT) as u8
     }
 }
 
@@ -27,8 +16,8 @@ mod test {
     use pretty_assertions::assert_eq;
 
     #[test]
-    fn from_u32() {
+    fn decode_u32() {
         let instruction = u32::from_le(0b_0100100_01010_01100_101_01000_0010011);
-        assert_eq!(*CsrImm::from(instruction), 12);
+        assert_eq!(CsrImm::decode(instruction), 12);
     }
 }

--- a/src/instructions/funct3.rs
+++ b/src/instructions/funct3.rs
@@ -1,23 +1,12 @@
-use std::ops::Deref;
-
-pub(super) struct Funct3(u8);
+pub(super) struct Funct3;
 
 impl Funct3 {
     const MASK: u32 = u32::from_le(0b_0000000_00000_00000_111_00000_0000000);
     const RSHIFT: usize = 12;
-}
 
-impl From<u32> for Funct3 {
-    fn from(value: u32) -> Self {
-        Self(((value & Self::MASK) >> Self::RSHIFT) as u8)
-    }
-}
-
-impl Deref for Funct3 {
-    type Target = u8;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
+    #[inline]
+    pub(super) const fn decode(value: u32) -> u8 {
+        ((value & Self::MASK) >> Self::RSHIFT) as u8
     }
 }
 
@@ -27,8 +16,8 @@ mod test {
     use pretty_assertions::assert_eq;
 
     #[test]
-    fn from_u32() {
+    fn decode_u32() {
         let instruction = u32::from_le(0b_0100100_01000_01000_101_00000_0010011);
-        assert_eq!(*Funct3::from(instruction), 0b_101);
+        assert_eq!(Funct3::decode(instruction), 0b_101);
     }
 }

--- a/src/instructions/funct6.rs
+++ b/src/instructions/funct6.rs
@@ -1,25 +1,14 @@
-use std::ops::Deref;
-
 /// On 64-bit architectures, bit 25 is part of the shift amount - hence rather than having a funct7,
 /// we have a funct6
-pub(super) struct Funct6(u8);
+pub(super) struct Funct6;
 
 impl Funct6 {
     const MASK: u32 = u32::from_le(0b_1111110_00000_00000_000_00000_0000000);
     const RSHIFT: usize = 26;
-}
 
-impl From<u32> for Funct6 {
-    fn from(value: u32) -> Self {
-        Self(((value & Self::MASK) >> Self::RSHIFT) as u8)
-    }
-}
-
-impl Deref for Funct6 {
-    type Target = u8;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
+    #[inline]
+    pub(super) const fn decode(value: u32) -> u8 {
+        ((value & Self::MASK) >> Self::RSHIFT) as u8
     }
 }
 
@@ -29,8 +18,8 @@ mod test {
     use pretty_assertions::assert_eq;
 
     #[test]
-    fn from_u32() {
+    fn decode_u32() {
         let instruction = u32::from_le(0b_0100100_01000_01000_101_00000_0010011);
-        assert_eq!(*Funct6::from(instruction), 0b_010010);
+        assert_eq!(Funct6::decode(instruction), 0b_010010);
     }
 }

--- a/src/instructions/funct7.rs
+++ b/src/instructions/funct7.rs
@@ -1,23 +1,12 @@
-use std::ops::Deref;
-
-pub(super) struct Funct7(u8);
+pub(super) struct Funct7;
 
 impl Funct7 {
     const MASK: u32 = u32::from_le(0b_1111111_00000_00000_000_00000_0000000);
     const RSHIFT: usize = 25;
-}
 
-impl From<u32> for Funct7 {
-    fn from(value: u32) -> Self {
-        Self(((value & Self::MASK) >> Self::RSHIFT) as u8)
-    }
-}
-
-impl Deref for Funct7 {
-    type Target = u8;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
+    #[inline]
+    pub(super) const fn decode(value: u32) -> u8 {
+        ((value & Self::MASK) >> Self::RSHIFT) as u8
     }
 }
 
@@ -27,8 +16,8 @@ mod test {
     use pretty_assertions::assert_eq;
 
     #[test]
-    fn from_u32() {
+    fn decode_u32() {
         let instruction = u32::from_le(0b_0100100_01000_01000_101_00000_0010011);
-        assert_eq!(*Funct7::from(instruction), 0b_0100100);
+        assert_eq!(Funct7::decode(instruction), 0b_0100100);
     }
 }

--- a/src/instructions/immi.rs
+++ b/src/instructions/immi.rs
@@ -1,23 +1,12 @@
-use std::ops::Deref;
-
-pub(super) struct ImmI(i16);
+pub(super) struct ImmI;
 
 impl ImmI {
     const MASK: u32 = u32::from_le(0b_1111111_11111_00000_000_00000_0000000);
     const RSHIFT: usize = 20;
-}
 
-impl From<u32> for ImmI {
-    fn from(value: u32) -> Self {
-        Self((((value & Self::MASK) as i32) >> Self::RSHIFT) as i16)
-    }
-}
-
-impl Deref for ImmI {
-    type Target = i16;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
+    #[inline]
+    pub(super) const fn decode(value: u32) -> i16 {
+        (((value & Self::MASK) as i32) >> Self::RSHIFT) as i16
     }
 }
 
@@ -29,26 +18,26 @@ mod test {
     use super::*;
 
     #[test]
-    fn from_u32() {
+    fn decode_u32() {
         let instruction = u32::from_le(0b_0100100_01010_01100_101_01000_0010011);
-        assert_eq!(*ImmI::from(instruction), i16::from_le(0b_0100100_01010));
+        assert_eq!(ImmI::decode(instruction), i16::from_le(0b_0100100_01010));
     }
 
     #[test]
-    fn from_u12_negative_one() {
+    fn decode_u32_negative_one() {
         let instruction = u32::from_le(0b_1111111_11111_01100_101_01000_0010011);
-        assert_eq!(*ImmI::from(instruction), -1);
+        assert_eq!(ImmI::decode(instruction), -1);
     }
 
     #[test]
-    fn from_u12_min() {
+    fn decode_u32_min() {
         let instruction = u32::from_le(0b_1000000_00000_01100_101_01000_0010011);
-        assert_eq!(*ImmI::from(instruction), i12::MIN);
+        assert_eq!(ImmI::decode(instruction), i12::MIN);
     }
 
     #[test]
-    fn from_u12_max() {
+    fn decode_u32_max() {
         let instruction = u32::from_le(0b_0111111_11111_01100_101_01000_0010011);
-        assert_eq!(*ImmI::from(instruction), i12::MAX);
+        assert_eq!(ImmI::decode(instruction), i12::MAX);
     }
 }

--- a/src/instructions/immu.rs
+++ b/src/instructions/immu.rs
@@ -1,23 +1,12 @@
-use std::ops::Deref;
-
-pub(super) struct ImmU(i32);
+pub(super) struct ImmU;
 
 impl ImmU {
     pub(super) const MASK: u32 = u32::from_le(0b_1111111_11111_11111_111_00000_0000000);
     pub(super) const RSHIFT: usize = 12;
-}
 
-impl From<u32> for ImmU {
-    fn from(value: u32) -> Self {
-        Self(((value & Self::MASK) >> Self::RSHIFT) as i32)
-    }
-}
-
-impl Deref for ImmU {
-    type Target = i32;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
+    #[inline]
+    pub(super) const fn decode(value: u32) -> i32 {
+        ((value & Self::MASK) >> Self::RSHIFT) as i32
     }
 }
 
@@ -27,10 +16,10 @@ mod test {
     use pretty_assertions::assert_eq;
 
     #[test]
-    fn from_u32() {
+    fn decode_u32() {
         let instruction = u32::from_le(0b_0100100_01010_01100_101_11000_0110111);
         assert_eq!(
-            *ImmU::from(instruction),
+            ImmU::decode(instruction),
             i32::from_le(0b_0100100_01010_01100_101)
         );
     }

--- a/src/instructions/impl_instruction_set.rs
+++ b/src/instructions/impl_instruction_set.rs
@@ -13,7 +13,7 @@ impl InstructionSet for Instruction {
     type CSRType = CSR32;
 
     fn decode(raw_instruction: u32) -> Result<Self, Exception> {
-        Ok(raw_instruction.into())
+        raw_instruction.try_into()
     }
 
     fn execute(

--- a/src/instructions/rd.rs
+++ b/src/instructions/rd.rs
@@ -1,25 +1,14 @@
-use std::ops::Deref;
-
 use crate::registers::Register;
 
-pub(super) struct Rd(Register);
+pub(super) struct Rd;
 
 impl Rd {
     const MASK: u32 = u32::from_le(0b_0000000_00000_00000_000_11111_0000000);
     const RSHIFT: usize = 7;
-}
 
-impl From<u32> for Rd {
-    fn from(value: u32) -> Self {
-        Self(Register::from(((value & Self::MASK) >> Self::RSHIFT) as u8))
-    }
-}
-
-impl Deref for Rd {
-    type Target = Register;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
+    #[inline]
+    pub(super) const fn decode(value: u32) -> Register {
+        Register::const_from(((value & Self::MASK) >> Self::RSHIFT) as u8)
     }
 }
 
@@ -29,8 +18,8 @@ mod test {
     use pretty_assertions::assert_eq;
 
     #[test]
-    fn from_u32() {
+    fn decode_u32() {
         let instruction = u32::from_le(0b_0100100_01000_01000_101_01000_0010011);
-        assert_eq!(*Rd::from(instruction), Register::S0);
+        assert_eq!(Rd::decode(instruction), Register::S0);
     }
 }

--- a/src/instructions/rs1.rs
+++ b/src/instructions/rs1.rs
@@ -1,25 +1,14 @@
-use std::ops::Deref;
-
 use crate::registers::Register;
 
-pub(super) struct Rs1(Register);
+pub(super) struct Rs1;
 
 impl Rs1 {
     const MASK: u32 = u32::from_le(0b_0000000_00000_11111_000_00000_0000000);
     const RSHIFT: usize = 15;
-}
 
-impl From<u32> for Rs1 {
-    fn from(value: u32) -> Self {
-        Self(Register::from(((value & Self::MASK) >> Self::RSHIFT) as u8))
-    }
-}
-
-impl Deref for Rs1 {
-    type Target = Register;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
+    #[inline]
+    pub(super) const fn decode(value: u32) -> Register {
+        Register::const_from(((value & Self::MASK) >> Self::RSHIFT) as u8)
     }
 }
 
@@ -29,8 +18,8 @@ mod test {
     use pretty_assertions::assert_eq;
 
     #[test]
-    fn from_u32() {
+    fn decode_u32() {
         let instruction = u32::from_le(0b_0100100_01010_01100_101_01000_0010011);
-        assert_eq!(*Rs1::from(instruction), Register::A2);
+        assert_eq!(Rs1::decode(instruction), Register::A2);
     }
 }

--- a/src/instructions/rs2.rs
+++ b/src/instructions/rs2.rs
@@ -1,25 +1,14 @@
-use std::ops::Deref;
-
 use crate::registers::Register;
 
-pub(super) struct Rs2(Register);
+pub(super) struct Rs2;
 
 impl Rs2 {
     const MASK: u32 = u32::from_le(0b_0000000_11111_00000_000_00000_0000000);
     const RSHIFT: usize = 20;
-}
 
-impl From<u32> for Rs2 {
-    fn from(value: u32) -> Self {
-        Self(Register::from(((value & Self::MASK) >> Self::RSHIFT) as u8))
-    }
-}
-
-impl Deref for Rs2 {
-    type Target = Register;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
+    #[inline]
+    pub(super) const fn decode(value: u32) -> Register {
+        Register::const_from(((value & Self::MASK) >> Self::RSHIFT) as u8)
     }
 }
 
@@ -29,8 +18,8 @@ mod test {
     use pretty_assertions::assert_eq;
 
     #[test]
-    fn from_u32() {
+    fn decode_u32() {
         let instruction = u32::from_le(0b_0100100_01010_01100_101_01000_0010011);
-        assert_eq!(*Rs2::from(instruction), Register::A0);
+        assert_eq!(Rs2::decode(instruction), Register::A0);
     }
 }

--- a/src/instructions/shamt.rs
+++ b/src/instructions/shamt.rs
@@ -1,23 +1,11 @@
-use std::ops::Deref;
-
-pub(super) struct Shamt(u8);
+pub(super) struct Shamt;
 
 impl Shamt {
     const MASK: u32 = u32::from_le(0b_0000001_11111_00000_000_00000_0000000);
     const RSHIFT: usize = 20;
-}
 
-impl From<u32> for Shamt {
-    fn from(value: u32) -> Self {
-        Self(((value & Self::MASK) >> Self::RSHIFT) as u8)
-    }
-}
-
-impl Deref for Shamt {
-    type Target = u8;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
+    pub(super) const fn decode(value: u32) -> u8 {
+        ((value & Self::MASK) >> Self::RSHIFT) as u8
     }
 }
 
@@ -27,11 +15,11 @@ mod test {
     use pretty_assertions::assert_eq;
 
     #[test]
-    fn from_u32() {
+    fn decode_u32() {
         let instruction = u32::from_le(0b_0100100_00110_01100_101_01000_0010011);
-        assert_eq!(*Shamt::from(instruction), 6);
+        assert_eq!(Shamt::decode(instruction), 6);
         // For 64 bit architectures, bit 25 is intepreted as part of the shift amount
         let instruction = u32::from_le(0b_0100101_00110_01100_101_01000_0010011);
-        assert_eq!(*Shamt::from(instruction), 38);
+        assert_eq!(Shamt::decode(instruction), 38);
     }
 }

--- a/src/instructions/simmi.rs
+++ b/src/instructions/simmi.rs
@@ -1,28 +1,15 @@
-use std::ops::Deref;
-
-pub(super) struct SImmI(i16);
+pub(super) struct SImmI;
 
 impl SImmI {
     const U_MASK: u32 = u32::from_le(0b_1111111_00000_00000_000_00000_0000000);
     const L_MASK: u32 = u32::from_le(0b_0000000_00000_00000_000_11111_0000000);
     const U_RSHIFT: usize = 20;
     const L_RSHIFT: usize = 7;
-}
 
-impl From<u32> for SImmI {
-    fn from(value: u32) -> Self {
-        Self(
-            ((((value & Self::U_MASK) as i32) >> Self::U_RSHIFT)
-                + (((value & Self::L_MASK) as i32) >> Self::L_RSHIFT)) as i16,
-        )
-    }
-}
-
-impl Deref for SImmI {
-    type Target = i16;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
+    #[inline]
+    pub(super) const fn decode(value: u32) -> i16 {
+        ((((value & Self::U_MASK) as i32) >> Self::U_RSHIFT)
+            + (((value & Self::L_MASK) as i32) >> Self::L_RSHIFT)) as i16
     }
 }
 
@@ -34,26 +21,26 @@ mod test {
     use super::*;
 
     #[test]
-    fn from_u32() {
+    fn decode_u32() {
         let instruction = u32::from_le(0b_0100100_01010_01100_101_01010_0010011);
-        assert_eq!(*SImmI::from(instruction), i16::from_le(0b_0100100_01010));
+        assert_eq!(SImmI::decode(instruction), i16::from_le(0b_0100100_01010));
     }
 
     #[test]
-    fn from_u12_negative_one() {
+    fn decode_u32_negative_one() {
         let instruction = u32::from_le(0b_1111111_11111_01100_101_11111_0010011);
-        assert_eq!(*SImmI::from(instruction), -1);
+        assert_eq!(SImmI::decode(instruction), -1);
     }
 
     #[test]
-    fn from_u12_min() {
+    fn decode_u32_min() {
         let instruction = u32::from_le(0b_1000000_01000_01100_101_00000_0010011);
-        assert_eq!(*SImmI::from(instruction), i12::MIN);
+        assert_eq!(SImmI::decode(instruction), i12::MIN);
     }
 
     #[test]
-    fn from_u12_max() {
+    fn decode_u32_max() {
         let instruction = u32::from_le(0b_0111111_11011_01100_101_11111_0010011);
-        assert_eq!(*SImmI::from(instruction), i12::MAX);
+        assert_eq!(SImmI::decode(instruction), i12::MAX);
     }
 }

--- a/src/registers.rs
+++ b/src/registers.rs
@@ -203,8 +203,8 @@ pub(super) enum Register {
     T6 = 31,
 }
 
-impl From<u8> for Register {
-    fn from(value: u8) -> Register {
+impl Register {
+    pub(crate) const fn const_from(value: u8) -> Register {
         match value & 0b_0001_1111 {
             0 => Register::ZERO,
             1 => Register::RA,
@@ -238,8 +238,14 @@ impl From<u8> for Register {
             29 => Register::T4,
             30 => Register::T5,
             31 => Register::T6,
-            _ => unreachable!("Already masked the value"),
+            _ => panic!("Unreachable: Already masked the value"),
         }
+    }
+}
+
+impl From<u8> for Register {
+    fn from(value: u8) -> Register {
+        Self::const_from(value)
     }
 }
 


### PR DESCRIPTION
This PR makes the instruction decode function `const`. Therefore this can be evaluated at compile time for optomization purposes.
