### PR TITLE
Properly make use of instruct size when incrementing the programme counter

### DIFF
--- a/src/instruction_set.rs
+++ b/src/instruction_set.rs
@@ -16,9 +16,7 @@ pub trait InstructionSet: Sized {
     ) -> Result<(), Exception>;
 
     /// Returns the size of this instruction in number of bytes
-    fn instruction_size(&self) -> usize {
-        4
-    }
+    fn instruction_size(&self) -> Self::RegisterType;
 
     const SHIFT_MASK: Self::RegisterType;
 }

--- a/src/instructions/impl_instruction_set.rs
+++ b/src/instructions/impl_instruction_set.rs
@@ -12,10 +12,12 @@ impl InstructionSet for Instruction {
     type RegisterType = i32;
     type CSRType = CSR32;
 
+    #[inline]
     fn decode(raw_instruction: u32) -> Result<Self, Exception> {
         Ok(raw_instruction.into())
     }
 
+    #[inline]
     fn instruction_size(&self) -> Self::RegisterType {
         4
     }

--- a/src/instructions/impl_instruction_set.rs
+++ b/src/instructions/impl_instruction_set.rs
@@ -16,13 +16,17 @@ impl InstructionSet for Instruction {
         Ok(raw_instruction.into())
     }
 
+    fn instruction_size(&self) -> Self::RegisterType {
+        4
+    }
+
     fn execute(
         self,
         processor: &mut Processor<Self::RegisterType, Self::CSRType>,
     ) -> Result<(), Exception> {
         // By default, after this instruction, we will move to the next one. Instructions that do
         // something different e.g. JAL can set this variable to modify the pc.
-        let pc = processor.pc + 4;
+        let pc = processor.pc + self.instruction_size();
 
         match self {
             Instruction::LUI { rd, imm } => processor.registers[rd] = imm << 12,


### PR DESCRIPTION
Part of the instruction set trait included the instruction size function. We should therefore make use of this when incrementing the programme counter.
