### PR TITLE
Encode instructions

### DIFF
--- a/src/instructions/csr.rs
+++ b/src/instructions/csr.rs
@@ -8,6 +8,11 @@ impl Csr {
     pub(super) const fn decode(value: u32) -> u16 {
         ((value & Self::MASK) >> Self::RSHIFT) as u16
     }
+
+    #[inline]
+    pub(super) const fn encode(value: u16) -> u32 {
+        (value as u32) << Self::RSHIFT
+    }
 }
 
 #[cfg(test)]
@@ -16,8 +21,14 @@ mod test {
     use pretty_assertions::assert_eq;
 
     #[test]
-    fn decode_u32() {
+    fn decode() {
         let instruction = u32::from_le(0b_1111111_11111_01100_101_11000_0110111);
-        assert_eq!(Csr::decode(instruction), 4095);
+        assert_eq!(Csr::decode(instruction), 0b_1111111_11111);
+    }
+
+    #[test]
+    fn encode() {
+        let instruction = u32::from_le(0b_1111111_11111_00000_000_00000_0000000);
+        assert_eq!(Csr::encode(0b_1111111_11111), instruction);
     }
 }

--- a/src/instructions/csr.rs
+++ b/src/instructions/csr.rs
@@ -1,12 +1,15 @@
 pub(super) struct Csr;
 
 impl Csr {
+    /// This is useful as a reference but not actually required for extracting this part of the
+    /// instruction
+    #[allow(unused)]
     const MASK: u32 = u32::from_le(0b_1111111_11111_00000_000_00000_0000000);
     const RSHIFT: usize = 20;
 
     #[inline]
     pub(super) const fn decode(value: u32) -> u16 {
-        ((value & Self::MASK) >> Self::RSHIFT) as u16
+        (value >> Self::RSHIFT) as u16
     }
 
     #[inline]

--- a/src/instructions/csr_imm.rs
+++ b/src/instructions/csr_imm.rs
@@ -8,6 +8,11 @@ impl CsrImm {
     pub(super) const fn decode(value: u32) -> u8 {
         ((value & Self::MASK) >> Self::RSHIFT) as u8
     }
+
+    #[inline]
+    pub(super) const fn encode(value: u8) -> u32 {
+        (value as u32) << Self::RSHIFT & Self::MASK
+    }
 }
 
 #[cfg(test)]
@@ -16,8 +21,20 @@ mod test {
     use pretty_assertions::assert_eq;
 
     #[test]
-    fn decode_u32() {
+    fn decode() {
         let instruction = u32::from_le(0b_0100100_01010_01100_101_01000_0010011);
-        assert_eq!(CsrImm::decode(instruction), 12);
+        assert_eq!(CsrImm::decode(instruction), 0b_01100);
+    }
+
+    #[test]
+    fn encode() {
+        let instruction = u32::from_le(0b_0000000_00000_01100_000_00000_0000000);
+        assert_eq!(CsrImm::encode(0b_01100), instruction);
+    }
+
+    #[test]
+    fn encode_mask() {
+        let instruction = u32::from_le(0b_0000000_00000_11111_000_00000_0000000);
+        assert_eq!(CsrImm::encode(0b_0011_1111), instruction);
     }
 }

--- a/src/instructions/funct3.rs
+++ b/src/instructions/funct3.rs
@@ -8,6 +8,11 @@ impl Funct3 {
     pub(super) const fn decode(value: u32) -> u8 {
         ((value & Self::MASK) >> Self::RSHIFT) as u8
     }
+
+    #[inline]
+    pub(super) const fn encode(value: u8) -> u32 {
+        (value as u32) << Self::RSHIFT & Self::MASK
+    }
 }
 
 #[cfg(test)]
@@ -16,8 +21,20 @@ mod test {
     use pretty_assertions::assert_eq;
 
     #[test]
-    fn decode_u32() {
+    fn decode() {
         let instruction = u32::from_le(0b_0100100_01000_01000_101_00000_0010011);
         assert_eq!(Funct3::decode(instruction), 0b_101);
+    }
+
+    #[test]
+    fn encode() {
+        let instruction = u32::from_le(0b_0000000_00000_00000_101_00000_0000000);
+        assert_eq!(Funct3::encode(0b_101), instruction);
+    }
+
+    #[test]
+    fn encode_mask() {
+        let instruction = u32::from_le(0b_0000000_00000_00000_001_00000_0000000);
+        assert_eq!(Funct3::encode(0b_1001), instruction);
     }
 }

--- a/src/instructions/funct6.rs
+++ b/src/instructions/funct6.rs
@@ -3,12 +3,15 @@
 pub(super) struct Funct6;
 
 impl Funct6 {
+    /// This is useful as a reference but not actually required for extracting this part of the
+    /// instruction
+    #[allow(unused)]
     const MASK: u32 = u32::from_le(0b_1111110_00000_00000_000_00000_0000000);
     const RSHIFT: usize = 26;
 
     #[inline]
     pub(super) const fn decode(value: u32) -> u8 {
-        ((value & Self::MASK) >> Self::RSHIFT) as u8
+        (value >> Self::RSHIFT) as u8
     }
 
     #[inline]

--- a/src/instructions/funct6.rs
+++ b/src/instructions/funct6.rs
@@ -10,6 +10,11 @@ impl Funct6 {
     pub(super) const fn decode(value: u32) -> u8 {
         ((value & Self::MASK) >> Self::RSHIFT) as u8
     }
+
+    #[inline]
+    pub(super) const fn encode(value: u8) -> u32 {
+        (value as u32) << Self::RSHIFT
+    }
 }
 
 #[cfg(test)]
@@ -18,8 +23,20 @@ mod test {
     use pretty_assertions::assert_eq;
 
     #[test]
-    fn decode_u32() {
+    fn decode() {
         let instruction = u32::from_le(0b_0100100_01000_01000_101_00000_0010011);
         assert_eq!(Funct6::decode(instruction), 0b_010010);
+    }
+
+    #[test]
+    fn encode() {
+        let instruction = u32::from_le(0b_0100100_00000_00000_000_00000_0000000);
+        assert_eq!(Funct6::encode(0b_010010), instruction);
+    }
+
+    #[test]
+    fn encode_mask() {
+        let instruction = u32::from_le(0b_0110100_00000_00000_000_00000_0000000);
+        assert_eq!(Funct6::encode(0b_1011010), instruction);
     }
 }

--- a/src/instructions/funct7.rs
+++ b/src/instructions/funct7.rs
@@ -1,12 +1,15 @@
 pub(super) struct Funct7;
 
 impl Funct7 {
+    /// This is useful as a reference but not actually required for extracting this part of the
+    /// instruction
+    #[allow(unused)]
     const MASK: u32 = u32::from_le(0b_1111111_00000_00000_000_00000_0000000);
     const RSHIFT: usize = 25;
 
     #[inline]
     pub(super) const fn decode(value: u32) -> u8 {
-        ((value & Self::MASK) >> Self::RSHIFT) as u8
+        (value >> Self::RSHIFT) as u8
     }
 
     #[inline]

--- a/src/instructions/funct7.rs
+++ b/src/instructions/funct7.rs
@@ -8,6 +8,11 @@ impl Funct7 {
     pub(super) const fn decode(value: u32) -> u8 {
         ((value & Self::MASK) >> Self::RSHIFT) as u8
     }
+
+    #[inline]
+    pub(super) const fn encode(value: u8) -> u32 {
+        (value as u32) << Self::RSHIFT
+    }
 }
 
 #[cfg(test)]
@@ -16,8 +21,20 @@ mod test {
     use pretty_assertions::assert_eq;
 
     #[test]
-    fn decode_u32() {
+    fn decode() {
         let instruction = u32::from_le(0b_0100100_01000_01000_101_00000_0010011);
         assert_eq!(Funct7::decode(instruction), 0b_0100100);
+    }
+
+    #[test]
+    fn encode() {
+        let instruction = u32::from_le(0b_0100100_00000_00000_000_00000_0000000);
+        assert_eq!(Funct7::encode(0b_0100100), instruction);
+    }
+
+    #[test]
+    fn encode_mask() {
+        let instruction = u32::from_le(0b_0110100_00000_00000_000_00000_0000000);
+        assert_eq!(Funct7::encode(0b_10110100), instruction);
     }
 }

--- a/src/instructions/immi.rs
+++ b/src/instructions/immi.rs
@@ -1,12 +1,15 @@
 pub(super) struct ImmI;
 
 impl ImmI {
+    /// This is useful as a reference but not actually required for extracting this part of the
+    /// instruction
+    #[allow(unused)]
     const MASK: u32 = u32::from_le(0b_1111111_11111_00000_000_00000_0000000);
     const RSHIFT: usize = 20;
 
     #[inline]
     pub(super) const fn decode(value: u32) -> i16 {
-        (((value & Self::MASK) as i32) >> Self::RSHIFT) as i16
+        ((value as i32) >> Self::RSHIFT) as i16
     }
 
     #[inline]

--- a/src/instructions/immi.rs
+++ b/src/instructions/immi.rs
@@ -8,6 +8,11 @@ impl ImmI {
     pub(super) const fn decode(value: u32) -> i16 {
         (((value & Self::MASK) as i32) >> Self::RSHIFT) as i16
     }
+
+    #[inline]
+    pub(super) const fn encode(value: i16) -> u32 {
+        (value as u32) << Self::RSHIFT
+    }
 }
 
 #[cfg(test)]
@@ -18,26 +23,38 @@ mod test {
     use super::*;
 
     #[test]
-    fn decode_u32() {
+    fn decode() {
         let instruction = u32::from_le(0b_0100100_01010_01100_101_01000_0010011);
         assert_eq!(ImmI::decode(instruction), i16::from_le(0b_0100100_01010));
     }
 
     #[test]
-    fn decode_u32_negative_one() {
+    fn decode_negative_one() {
         let instruction = u32::from_le(0b_1111111_11111_01100_101_01000_0010011);
         assert_eq!(ImmI::decode(instruction), -1);
     }
 
     #[test]
-    fn decode_u32_min() {
+    fn decode_min() {
         let instruction = u32::from_le(0b_1000000_00000_01100_101_01000_0010011);
         assert_eq!(ImmI::decode(instruction), i12::MIN);
     }
 
     #[test]
-    fn decode_u32_max() {
+    fn decode_max() {
         let instruction = u32::from_le(0b_0111111_11111_01100_101_01000_0010011);
         assert_eq!(ImmI::decode(instruction), i12::MAX);
+    }
+
+    #[test]
+    fn encode() {
+        let instruction = u32::from_le(0b_0100100_01010_00000_000_00000_0000000);
+        assert_eq!(ImmI::encode(0b_0100100_01010), instruction);
+    }
+
+    #[test]
+    fn encode_negative_one() {
+        let instruction = u32::from_le(0b_1111111_11111_00000_000_00000_0000000);
+        assert_eq!(ImmI::encode(-1), instruction);
     }
 }

--- a/src/instructions/immu.rs
+++ b/src/instructions/immu.rs
@@ -1,12 +1,15 @@
 pub(super) struct ImmU;
 
 impl ImmU {
+    /// This is useful as a reference but not actually required for extracting this part of the
+    /// instruction
+    #[allow(unused)]
     pub(super) const MASK: u32 = u32::from_le(0b_1111111_11111_11111_111_00000_0000000);
     pub(super) const RSHIFT: usize = 12;
 
     #[inline]
     pub(super) const fn decode(value: u32) -> i32 {
-        ((value & Self::MASK) >> Self::RSHIFT) as i32
+        (value >> Self::RSHIFT) as i32
     }
 
     #[inline]

--- a/src/instructions/immu.rs
+++ b/src/instructions/immu.rs
@@ -8,6 +8,11 @@ impl ImmU {
     pub(super) const fn decode(value: u32) -> i32 {
         ((value & Self::MASK) >> Self::RSHIFT) as i32
     }
+
+    #[inline]
+    pub(super) const fn encode(value: i32) -> u32 {
+        (value as u32) << Self::RSHIFT
+    }
 }
 
 #[cfg(test)]
@@ -16,11 +21,23 @@ mod test {
     use pretty_assertions::assert_eq;
 
     #[test]
-    fn decode_u32() {
+    fn decode() {
         let instruction = u32::from_le(0b_0100100_01010_01100_101_11000_0110111);
         assert_eq!(
             ImmU::decode(instruction),
             i32::from_le(0b_0100100_01010_01100_101)
         );
+    }
+
+    #[test]
+    fn encode() {
+        let instruction = u32::from_le(0b_0100100_01010_01100_101_00000_0000000);
+        assert_eq!(ImmU::encode(0b_0100100_01010_01100_101), instruction);
+    }
+
+    #[test]
+    fn encode_negative_one() {
+        let instruction = u32::from_le(0b_1111111_11111_11111_111_00000_0000000);
+        assert_eq!(ImmU::encode(-1), instruction);
     }
 }

--- a/src/instructions/mod.rs
+++ b/src/instructions/mod.rs
@@ -13,6 +13,7 @@ mod rs1;
 mod rs2;
 mod shamt;
 mod simmi;
+mod types;
 
 use self::{
     csr::Csr, csr_imm::CsrImm, funct3::Funct3, funct6::Funct6, funct7::Funct7, immi::ImmI,
@@ -547,12 +548,12 @@ impl Instruction {
                     rs1: Rs1::decode(value),
                     rs2: Rs2::decode(value),
                 },
-                (0b_110, 0b_0100000) => Instruction::OR {
+                (0b_110, 0b_0000000) => Instruction::OR {
                     rd: Rd::decode(value),
                     rs1: Rs1::decode(value),
                     rs2: Rs2::decode(value),
                 },
-                (0b_111, 0b_0100000) => Instruction::AND {
+                (0b_111, 0b_0000000) => Instruction::AND {
                     rd: Rd::decode(value),
                     rs1: Rs1::decode(value),
                     rs2: Rs2::decode(value),
@@ -642,6 +643,149 @@ impl Instruction {
         };
         Ok(instruction)
     }
+
+    pub(crate) const fn encode(self) -> u32 {
+        match self {
+            Instruction::LUI { rd, imm } => {
+                u32::from_le(0b_0000000_00000_00000_000_00000_0110111) + types::U::encode(rd, imm)
+            }
+            Instruction::AUIPC { rd, imm } => {
+                u32::from_le(0b_0000000_00000_00000_000_00000_0010111) + types::U::encode(rd, imm)
+            }
+            Instruction::ADDI { rd, rs1, imm } => {
+                u32::from_le(0b_0000000_00000_00000_000_00000_0010011)
+                    + types::I::encode(rd, rs1, imm)
+            }
+            Instruction::SLTI { rd, rs1, imm } => {
+                u32::from_le(0b_0000000_00000_00000_010_00000_0010011)
+                    + types::I::encode(rd, rs1, imm)
+            }
+            Instruction::SLTIU { rd, rs1, imm } => {
+                u32::from_le(0b_0000000_00000_00000_011_00000_0010011)
+                    + types::I::encode(rd, rs1, imm)
+            }
+            Instruction::XORI { rd, rs1, imm } => {
+                u32::from_le(0b_0000000_00000_00000_100_00000_0010011)
+                    + types::I::encode(rd, rs1, imm)
+            }
+            Instruction::ORI { rd, rs1, imm } => {
+                u32::from_le(0b_0000000_00000_00000_110_00000_0010011)
+                    + types::I::encode(rd, rs1, imm)
+            }
+            Instruction::ANDI { rd, rs1, imm } => {
+                u32::from_le(0b_0000000_00000_00000_111_00000_0010011)
+                    + types::I::encode(rd, rs1, imm)
+            }
+            Instruction::SLLI { rd, rs1, shamt } => {
+                u32::from_le(0b_0000000_00000_00000_001_00000_0010011)
+                    + types::I::encode_shamt(rd, rs1, shamt)
+            }
+            Instruction::SRLI { rd, rs1, shamt } => {
+                u32::from_le(0b_0000000_00000_00000_101_00000_0010011)
+                    + types::I::encode_shamt(rd, rs1, shamt)
+            }
+            Instruction::SRAI { rd, rs1, shamt } => {
+                u32::from_le(0b_0100000_00000_00000_101_00000_0010011)
+                    + types::I::encode_shamt(rd, rs1, shamt)
+            }
+            Instruction::ADD { rd, rs1, rs2 } => {
+                u32::from_le(0b_0000000_00000_00000_000_00000_0110011)
+                    + types::R::encode(rd, rs1, rs2)
+            }
+            Instruction::SUB { rd, rs1, rs2 } => {
+                u32::from_le(0b_0100000_00000_00000_000_00000_0110011)
+                    + types::R::encode(rd, rs1, rs2)
+            }
+            Instruction::SLL { rd, rs1, rs2 } => {
+                u32::from_le(0b_0000000_00000_00000_001_00000_0110011)
+                    + types::R::encode(rd, rs1, rs2)
+            }
+            Instruction::SLT { rd, rs1, rs2 } => {
+                u32::from_le(0b_0000000_00000_00000_010_00000_0110011)
+                    + types::R::encode(rd, rs1, rs2)
+            }
+            Instruction::SLTU { rd, rs1, rs2 } => {
+                u32::from_le(0b_0000000_00000_00000_011_00000_0110011)
+                    + types::R::encode(rd, rs1, rs2)
+            }
+            Instruction::XOR { rd, rs1, rs2 } => {
+                u32::from_le(0b_0000000_00000_00000_100_00000_0110011)
+                    + types::R::encode(rd, rs1, rs2)
+            }
+            Instruction::SRL { rd, rs1, rs2 } => {
+                u32::from_le(0b_0000000_00000_00000_101_00000_0110011)
+                    + types::R::encode(rd, rs1, rs2)
+            }
+            Instruction::SRA { rd, rs1, rs2 } => {
+                u32::from_le(0b_0100000_00000_00000_101_00000_0110011)
+                    + types::R::encode(rd, rs1, rs2)
+            }
+            Instruction::OR { rd, rs1, rs2 } => {
+                u32::from_le(0b_0000000_00000_00000_110_00000_0110011)
+                    + types::R::encode(rd, rs1, rs2)
+            }
+            Instruction::AND { rd, rs1, rs2 } => {
+                u32::from_le(0b_0000000_00000_00000_111_00000_0110011)
+                    + types::R::encode(rd, rs1, rs2)
+            }
+            Instruction::LB { rd, rs1, offset } => {
+                u32::from_le(0b_0000000_00000_00000_000_00000_0000011)
+                    + types::I::encode(rd, rs1, offset)
+            }
+            Instruction::LH { rd, rs1, offset } => {
+                u32::from_le(0b_0000000_00000_00000_001_00000_0000011)
+                    + types::I::encode(rd, rs1, offset)
+            }
+            Instruction::LW { rd, rs1, offset } => {
+                u32::from_le(0b_0000000_00000_00000_010_00000_0000011)
+                    + types::I::encode(rd, rs1, offset)
+            }
+            Instruction::LBU { rd, rs1, offset } => {
+                u32::from_le(0b_0000000_00000_00000_100_00000_0000011)
+                    + types::I::encode(rd, rs1, offset)
+            }
+            Instruction::LHU { rd, rs1, offset } => {
+                u32::from_le(0b_0000000_00000_00000_101_00000_0000011)
+                    + types::I::encode(rd, rs1, offset)
+            }
+            Instruction::SB { rs1, rs2, offset } => {
+                u32::from_le(0b_0000000_00000_00000_000_00000_0100011)
+                    + types::S::encode(rs1, rs2, offset)
+            }
+            Instruction::SH { rs1, rs2, offset } => {
+                u32::from_le(0b_0000000_00000_00000_001_00000_0100011)
+                    + types::S::encode(rs1, rs2, offset)
+            }
+            Instruction::SW { rs1, rs2, offset } => {
+                u32::from_le(0b_0000000_00000_00000_010_00000_0100011)
+                    + types::S::encode(rs1, rs2, offset)
+            }
+            Instruction::CSRRW { rd, rs1, csr } => {
+                u32::from_le(0b_0000000_00000_00000_001_00000_1110011)
+                    + types::I::encode_csr(rd, rs1, csr)
+            }
+            Instruction::CSRRS { rd, rs1, csr } => {
+                u32::from_le(0b_0000000_00000_00000_010_00000_1110011)
+                    + types::I::encode_csr(rd, rs1, csr)
+            }
+            Instruction::CSRRC { rd, rs1, csr } => {
+                u32::from_le(0b_0000000_00000_00000_011_00000_1110011)
+                    + types::I::encode_csr(rd, rs1, csr)
+            }
+            Instruction::CSRRWI { rd, csr, imm } => {
+                u32::from_le(0b_0000000_00000_00000_101_00000_1110011)
+                    + types::I::encode_csri(rd, imm, csr)
+            }
+            Instruction::CSRRSI { rd, csr, imm } => {
+                u32::from_le(0b_0000000_00000_00000_110_00000_1110011)
+                    + types::I::encode_csri(rd, imm, csr)
+            }
+            Instruction::CSRRCI { rd, csr, imm } => {
+                u32::from_le(0b_0000000_00000_00000_111_00000_1110011)
+                    + types::I::encode_csri(rd, imm, csr)
+            }
+        }
+    }
 }
 
 impl TryFrom<u32> for Instruction {
@@ -672,7 +816,7 @@ mod test {
     }
 
     #[test]
-    fn lui_from_i32() {
+    fn lui_from_u32() {
         assert_eq!(
             Instruction::from(u32::from_le(0b_0100100_01010_01100_101_11000_0110111)),
             Instruction::LUI {
@@ -683,7 +827,19 @@ mod test {
     }
 
     #[test]
-    fn auipc_from_i32() {
+    fn encode_lui() {
+        assert_eq!(
+            Instruction::LUI {
+                rd: Register::S8,
+                imm: 0x48A65
+            }
+            .encode(),
+            u32::from_le(0b_0100100_01010_01100_101_11000_0110111)
+        );
+    }
+
+    #[test]
+    fn auipc_from_u32() {
         assert_eq!(
             Instruction::from(u32::from_le(0b_0100100_01010_01100_111_11100_0010111)),
             Instruction::AUIPC {
@@ -694,7 +850,19 @@ mod test {
     }
 
     #[test]
-    fn addi_from_i32() {
+    fn encode_auipc() {
+        assert_eq!(
+            Instruction::AUIPC {
+                rd: Register::T3,
+                imm: 0x48A67
+            }
+            .encode(),
+            u32::from_le(0b_0100100_01010_01100_111_11100_0010111),
+        );
+    }
+
+    #[test]
+    fn addi_from_u32() {
         assert_eq!(
             Instruction::from(u32::from_le(0b_0000001_00000_00000_000_00001_0010011)),
             Instruction::ADDI {
@@ -706,7 +874,20 @@ mod test {
     }
 
     #[test]
-    fn slti_from_i32() {
+    fn encode_addi() {
+        assert_eq!(
+            Instruction::ADDI {
+                rd: Register::RA,
+                rs1: Register::ZERO,
+                imm: 32
+            }
+            .encode(),
+            u32::from_le(0b_0000001_00000_00000_000_00001_0010011),
+        );
+    }
+
+    #[test]
+    fn slti_from_u32() {
         assert_eq!(
             Instruction::from(u32::from_le(0b_0000001_00000_00100_010_00011_0010011)),
             Instruction::SLTI {
@@ -718,7 +899,20 @@ mod test {
     }
 
     #[test]
-    fn sltiu_from_i32() {
+    fn encode_slti() {
+        assert_eq!(
+            Instruction::SLTI {
+                rd: Register::GP,
+                rs1: Register::TP,
+                imm: 32
+            }
+            .encode(),
+            u32::from_le(0b_0000001_00000_00100_010_00011_0010011),
+        );
+    }
+
+    #[test]
+    fn sltiu_from_u32() {
         assert_eq!(
             Instruction::from(u32::from_le(0b_0000011_00000_00100_011_00011_0010011)),
             Instruction::SLTIU {
@@ -730,7 +924,20 @@ mod test {
     }
 
     #[test]
-    fn xori_from_i32() {
+    fn encode_sltiu() {
+        assert_eq!(
+            Instruction::SLTIU {
+                rd: Register::GP,
+                rs1: Register::TP,
+                imm: 96
+            }
+            .encode(),
+            u32::from_le(0b_0000011_00000_00100_011_00011_0010011),
+        );
+    }
+
+    #[test]
+    fn xori_from_u32() {
         assert_eq!(
             Instruction::from(u32::from_le(0b_1111111_11000_01100_100_01011_0010011)),
             Instruction::XORI {
@@ -742,7 +949,20 @@ mod test {
     }
 
     #[test]
-    fn ori_from_i32() {
+    fn encode_xori() {
+        assert_eq!(
+            Instruction::XORI {
+                rd: Register::A1,
+                rs1: Register::A2,
+                imm: -8
+            }
+            .encode(),
+            u32::from_le(0b_1111111_11000_01100_100_01011_0010011),
+        );
+    }
+
+    #[test]
+    fn ori_from_u32() {
         assert_eq!(
             Instruction::from(u32::from_le(0b_1111111_01000_01101_110_10011_0010011)),
             Instruction::ORI {
@@ -754,7 +974,20 @@ mod test {
     }
 
     #[test]
-    fn andi_from_i32() {
+    fn encode_ori() {
+        assert_eq!(
+            Instruction::ORI {
+                rd: Register::S3,
+                rs1: Register::A3,
+                imm: -24
+            }
+            .encode(),
+            u32::from_le(0b_1111111_01000_01101_110_10011_0010011),
+        );
+    }
+
+    #[test]
+    fn andi_from_u32() {
         assert_eq!(
             Instruction::from(u32::from_le(0b_0000010_01000_11100_111_01111_0010011)),
             Instruction::ANDI {
@@ -766,7 +999,20 @@ mod test {
     }
 
     #[test]
-    fn slli_from_i32() {
+    fn encode_andi() {
+        assert_eq!(
+            Instruction::ANDI {
+                rd: Register::A5,
+                rs1: Register::T3,
+                imm: 72
+            }
+            .encode(),
+            u32::from_le(0b_0000010_01000_11100_111_01111_0010011),
+        );
+    }
+
+    #[test]
+    fn slli_from_u32() {
         assert_eq!(
             Instruction::from(u32::from_le(0b_0000000_01010_10010_001_01101_0010011)),
             Instruction::SLLI {
@@ -778,7 +1024,20 @@ mod test {
     }
 
     #[test]
-    fn srli_from_i32() {
+    fn encode_slli() {
+        assert_eq!(
+            Instruction::SLLI {
+                rd: Register::A3,
+                rs1: Register::S2,
+                shamt: 10
+            }
+            .encode(),
+            u32::from_le(0b_0000000_01010_10010_001_01101_0010011),
+        );
+    }
+
+    #[test]
+    fn srli_from_u32() {
         assert_eq!(
             Instruction::from(u32::from_le(0b_0000001_01010_10011_101_01110_0010011)),
             Instruction::SRLI {
@@ -790,7 +1049,20 @@ mod test {
     }
 
     #[test]
-    fn srai_from_i32() {
+    fn encode_srli() {
+        assert_eq!(
+            Instruction::SRLI {
+                rd: Register::A4,
+                rs1: Register::S3,
+                shamt: 42
+            }
+            .encode(),
+            u32::from_le(0b_0000001_01010_10011_101_01110_0010011),
+        );
+    }
+
+    #[test]
+    fn srai_from_u32() {
         assert_eq!(
             Instruction::from(u32::from_le(0b_0100000_11010_10100_101_10000_0010011)),
             Instruction::SRAI {
@@ -802,7 +1074,20 @@ mod test {
     }
 
     #[test]
-    fn add_from_i32() {
+    fn encode_srai() {
+        assert_eq!(
+            Instruction::SRAI {
+                rd: Register::A6,
+                rs1: Register::S4,
+                shamt: 26
+            }
+            .encode(),
+            u32::from_le(0b_0100000_11010_10100_101_10000_0010011),
+        );
+    }
+
+    #[test]
+    fn add_from_u32() {
         assert_eq!(
             Instruction::from(u32::from_le(0b_0000000_01101_01011_000_00010_0110011)),
             Instruction::ADD {
@@ -814,7 +1099,20 @@ mod test {
     }
 
     #[test]
-    fn sub_from_i32() {
+    fn encode_add() {
+        assert_eq!(
+            Instruction::ADD {
+                rd: Register::SP,
+                rs1: Register::A1,
+                rs2: Register::A3,
+            }
+            .encode(),
+            u32::from_le(0b_0000000_01101_01011_000_00010_0110011),
+        );
+    }
+
+    #[test]
+    fn sub_from_u32() {
         assert_eq!(
             Instruction::from(u32::from_le(0b_0100000_11101_11011_000_00010_0110011)),
             Instruction::SUB {
@@ -826,7 +1124,20 @@ mod test {
     }
 
     #[test]
-    fn sll_from_i32() {
+    fn encode_sub() {
+        assert_eq!(
+            Instruction::SUB {
+                rd: Register::SP,
+                rs1: Register::S11,
+                rs2: Register::T4,
+            }
+            .encode(),
+            u32::from_le(0b_0100000_11101_11011_000_00010_0110011),
+        );
+    }
+
+    #[test]
+    fn sll_from_u32() {
         assert_eq!(
             Instruction::from(u32::from_le(0b_0000000_10110_10101_001_10100_0110011)),
             Instruction::SLL {
@@ -838,7 +1149,20 @@ mod test {
     }
 
     #[test]
-    fn stl_from_i32() {
+    fn encode_sll() {
+        assert_eq!(
+            Instruction::SLL {
+                rd: Register::S4,
+                rs1: Register::S5,
+                rs2: Register::S6,
+            }
+            .encode(),
+            u32::from_le(0b_0000000_10110_10101_001_10100_0110011),
+        );
+    }
+
+    #[test]
+    fn stl_from_u32() {
         assert_eq!(
             Instruction::from(u32::from_le(0b_0000000_11100_10011_010_00110_0110011)),
             Instruction::SLT {
@@ -850,7 +1174,20 @@ mod test {
     }
 
     #[test]
-    fn stlu_from_i32() {
+    fn encode_stl() {
+        assert_eq!(
+            Instruction::SLT {
+                rd: Register::T1,
+                rs1: Register::S3,
+                rs2: Register::T3,
+            }
+            .encode(),
+            u32::from_le(0b_0000000_11100_10011_010_00110_0110011),
+        );
+    }
+
+    #[test]
+    fn stlu_from_u32() {
         assert_eq!(
             Instruction::from(u32::from_le(0b_0000000_11000_10001_011_01110_0110011)),
             Instruction::SLTU {
@@ -862,7 +1199,20 @@ mod test {
     }
 
     #[test]
-    fn xor_from_i32() {
+    fn encode_stlu() {
+        assert_eq!(
+            Instruction::SLTU {
+                rd: Register::A4,
+                rs1: Register::A7,
+                rs2: Register::S8,
+            }
+            .encode(),
+            u32::from_le(0b_0000000_11000_10001_011_01110_0110011),
+        );
+    }
+
+    #[test]
+    fn xor_from_u32() {
         assert_eq!(
             Instruction::from(u32::from_le(0b_0000000_00111_01010_100_00101_0110011)),
             Instruction::XOR {
@@ -874,7 +1224,20 @@ mod test {
     }
 
     #[test]
-    fn srl_from_i32() {
+    fn encode_xor() {
+        assert_eq!(
+            Instruction::XOR {
+                rd: Register::T0,
+                rs1: Register::A0,
+                rs2: Register::T2,
+            }
+            .encode(),
+            u32::from_le(0b_0000000_00111_01010_100_00101_0110011),
+        );
+    }
+
+    #[test]
+    fn srl_from_u32() {
         assert_eq!(
             Instruction::from(u32::from_le(0b_0000000_11001_11000_101_10111_0110011)),
             Instruction::SRL {
@@ -886,7 +1249,20 @@ mod test {
     }
 
     #[test]
-    fn sra_from_i32() {
+    fn encode_srl() {
+        assert_eq!(
+            Instruction::SRL {
+                rd: Register::S7,
+                rs1: Register::S8,
+                rs2: Register::S9,
+            }
+            .encode(),
+            u32::from_le(0b_0000000_11001_11000_101_10111_0110011),
+        );
+    }
+
+    #[test]
+    fn sra_from_u32() {
         assert_eq!(
             Instruction::from(u32::from_le(0b_0100000_11100_11011_101_11010_0110011)),
             Instruction::SRA {
@@ -898,9 +1274,22 @@ mod test {
     }
 
     #[test]
-    fn or_from_i32() {
+    fn encode_sra() {
         assert_eq!(
-            Instruction::from(u32::from_le(0b_0100000_11100_01001_110_01000_0110011)),
+            Instruction::SRA {
+                rd: Register::S10,
+                rs1: Register::S11,
+                rs2: Register::T3,
+            }
+            .encode(),
+            u32::from_le(0b_0100000_11100_11011_101_11010_0110011),
+        );
+    }
+
+    #[test]
+    fn or_from_u32() {
+        assert_eq!(
+            Instruction::from(u32::from_le(0b_0000000_11100_01001_110_01000_0110011)),
             Instruction::OR {
                 rd: Register::S0,
                 rs1: Register::S1,
@@ -910,9 +1299,22 @@ mod test {
     }
 
     #[test]
-    fn and_from_i32() {
+    fn encode_or() {
         assert_eq!(
-            Instruction::from(u32::from_le(0b_0100000_11111_11110_111_11101_0110011)),
+            Instruction::OR {
+                rd: Register::S0,
+                rs1: Register::S1,
+                rs2: Register::T3,
+            }
+            .encode(),
+            u32::from_le(0b_0000000_11100_01001_110_01000_0110011),
+        );
+    }
+
+    #[test]
+    fn and_from_u32() {
+        assert_eq!(
+            Instruction::from(u32::from_le(0b_0000000_11111_11110_111_11101_0110011)),
             Instruction::AND {
                 rd: Register::T4,
                 rs1: Register::T5,
@@ -922,7 +1324,20 @@ mod test {
     }
 
     #[test]
-    fn lb_from_i32() {
+    fn encode_and() {
+        assert_eq!(
+            Instruction::AND {
+                rd: Register::T4,
+                rs1: Register::T5,
+                rs2: Register::T6,
+            }
+            .encode(),
+            u32::from_le(0b_0000000_11111_11110_111_11101_0110011),
+        );
+    }
+
+    #[test]
+    fn lb_from_u32() {
         assert_eq!(
             Instruction::from(u32::from_le(0b_0000001_11001_01100_000_11100_0000011)),
             Instruction::LB {
@@ -934,7 +1349,20 @@ mod test {
     }
 
     #[test]
-    fn lh_from_i32() {
+    fn encode_lb() {
+        assert_eq!(
+            Instruction::LB {
+                rd: Register::T3,
+                rs1: Register::A2,
+                offset: 57,
+            }
+            .encode(),
+            u32::from_le(0b_0000001_11001_01100_000_11100_0000011),
+        );
+    }
+
+    #[test]
+    fn lh_from_u32() {
         assert_eq!(
             Instruction::from(u32::from_le(0b_0000001_11010_01100_001_11100_0000011)),
             Instruction::LH {
@@ -946,7 +1374,20 @@ mod test {
     }
 
     #[test]
-    fn lw_from_i32() {
+    fn encode_lh() {
+        assert_eq!(
+            Instruction::LH {
+                rd: Register::T3,
+                rs1: Register::A2,
+                offset: 58,
+            }
+            .encode(),
+            u32::from_le(0b_0000001_11010_01100_001_11100_0000011),
+        );
+    }
+
+    #[test]
+    fn lw_from_u32() {
         assert_eq!(
             Instruction::from(u32::from_le(0b_0000001_11000_01100_010_11100_0000011)),
             Instruction::LW {
@@ -958,7 +1399,20 @@ mod test {
     }
 
     #[test]
-    fn lbu_from_i32() {
+    fn encode_lw() {
+        assert_eq!(
+            Instruction::LW {
+                rd: Register::T3,
+                rs1: Register::A2,
+                offset: 56,
+            }
+            .encode(),
+            u32::from_le(0b_0000001_11000_01100_010_11100_0000011),
+        );
+    }
+
+    #[test]
+    fn lbu_from_u32() {
         assert_eq!(
             Instruction::from(u32::from_le(0b_0000001_11011_01100_100_11100_0000011)),
             Instruction::LBU {
@@ -970,7 +1424,20 @@ mod test {
     }
 
     #[test]
-    fn lhu_from_i32() {
+    fn encode_lbu() {
+        assert_eq!(
+            Instruction::LBU {
+                rd: Register::T3,
+                rs1: Register::A2,
+                offset: 59,
+            }
+            .encode(),
+            u32::from_le(0b_0000001_11011_01100_100_11100_0000011),
+        );
+    }
+
+    #[test]
+    fn lhu_from_u32() {
         assert_eq!(
             Instruction::from(u32::from_le(0b_0000001_11100_01100_101_11100_0000011)),
             Instruction::LHU {
@@ -982,7 +1449,20 @@ mod test {
     }
 
     #[test]
-    fn sb_from_i32() {
+    fn encode_lhu() {
+        assert_eq!(
+            Instruction::LHU {
+                rd: Register::T3,
+                rs1: Register::A2,
+                offset: 60,
+            }
+            .encode(),
+            u32::from_le(0b_0000001_11100_01100_101_11100_0000011),
+        );
+    }
+
+    #[test]
+    fn sb_from_u32() {
         assert_eq!(
             Instruction::from(u32::from_le(0b_0000001_11101_01101_000_11101_0100011)),
             Instruction::SB {
@@ -994,7 +1474,20 @@ mod test {
     }
 
     #[test]
-    fn sh_from_i32() {
+    fn encode_sb() {
+        assert_eq!(
+            Instruction::SB {
+                rs1: Register::A3,
+                rs2: Register::T4,
+                offset: 61,
+            }
+            .encode(),
+            u32::from_le(0b_0000001_11101_01101_000_11101_0100011),
+        );
+    }
+
+    #[test]
+    fn sh_from_u32() {
         assert_eq!(
             Instruction::from(u32::from_le(0b_0000001_11101_01101_001_11110_0100011)),
             Instruction::SH {
@@ -1006,7 +1499,20 @@ mod test {
     }
 
     #[test]
-    fn sw_from_i32() {
+    fn encode_sh() {
+        assert_eq!(
+            Instruction::SH {
+                rs1: Register::A3,
+                rs2: Register::T4,
+                offset: 62,
+            }
+            .encode(),
+            u32::from_le(0b_0000001_11101_01101_001_11110_0100011),
+        );
+    }
+
+    #[test]
+    fn sw_from_u32() {
         assert_eq!(
             Instruction::from(u32::from_le(0b_0000001_11111_01101_010_11111_0100011)),
             Instruction::SW {
@@ -1018,7 +1524,20 @@ mod test {
     }
 
     #[test]
-    fn csrrw_from_i32() {
+    fn encode_sw() {
+        assert_eq!(
+            Instruction::SW {
+                rs1: Register::A3,
+                rs2: Register::T6,
+                offset: 63,
+            }
+            .encode(),
+            u32::from_le(0b_0000001_11111_01101_010_11111_0100011),
+        );
+    }
+
+    #[test]
+    fn csrrw_from_u32() {
         assert_eq!(
             Instruction::from(u32::from_le(0b_0001001_11111_01111_001_11011_1110011)),
             Instruction::CSRRW {
@@ -1030,7 +1549,20 @@ mod test {
     }
 
     #[test]
-    fn csrrs_from_i32() {
+    fn encode_csrrw() {
+        assert_eq!(
+            Instruction::CSRRW {
+                rd: Register::S11,
+                rs1: Register::A5,
+                csr: 319,
+            }
+            .encode(),
+            u32::from_le(0b_0001001_11111_01111_001_11011_1110011),
+        );
+    }
+
+    #[test]
+    fn csrrs_from_u32() {
         assert_eq!(
             Instruction::from(u32::from_le(0b_0101001_11111_01011_010_10011_1110011)),
             Instruction::CSRRS {
@@ -1042,7 +1574,20 @@ mod test {
     }
 
     #[test]
-    fn csrrc_from_i32() {
+    fn encode_csrrs() {
+        assert_eq!(
+            Instruction::CSRRS {
+                rd: Register::S3,
+                rs1: Register::A1,
+                csr: 1343,
+            }
+            .encode(),
+            u32::from_le(0b_0101001_11111_01011_010_10011_1110011),
+        );
+    }
+
+    #[test]
+    fn csrrc_from_u32() {
         assert_eq!(
             Instruction::from(u32::from_le(0b_1101001_11111_01001_011_10111_1110011)),
             Instruction::CSRRC {
@@ -1054,7 +1599,20 @@ mod test {
     }
 
     #[test]
-    fn csrrwi_from_i32() {
+    fn encode_csrrc() {
+        assert_eq!(
+            Instruction::CSRRC {
+                rd: Register::S7,
+                rs1: Register::S1,
+                csr: 3391,
+            }
+            .encode(),
+            u32::from_le(0b_1101001_11111_01001_011_10111_1110011),
+        );
+    }
+
+    #[test]
+    fn csrrwi_from_u32() {
         assert_eq!(
             Instruction::from(u32::from_le(0b_0000001_11011_01001_101_10101_1110011)),
             Instruction::CSRRWI {
@@ -1066,7 +1624,20 @@ mod test {
     }
 
     #[test]
-    fn csrrsi_from_i32() {
+    fn encode_csrrwi() {
+        assert_eq!(
+            Instruction::CSRRWI {
+                rd: Register::S5,
+                imm: 9,
+                csr: 59,
+            }
+            .encode(),
+            u32::from_le(0b_0000001_11011_01001_101_10101_1110011),
+        );
+    }
+
+    #[test]
+    fn csrrsi_from_u32() {
         assert_eq!(
             Instruction::from(u32::from_le(0b_0000001_01010_11011_110_10100_1110011)),
             Instruction::CSRRSI {
@@ -1078,7 +1649,20 @@ mod test {
     }
 
     #[test]
-    fn csrrci_from_i32() {
+    fn encode_csrrsi() {
+        assert_eq!(
+            Instruction::CSRRSI {
+                rd: Register::S4,
+                imm: 27,
+                csr: 42,
+            }
+            .encode(),
+            u32::from_le(0b_0000001_01010_11011_110_10100_1110011),
+        );
+    }
+
+    #[test]
+    fn csrrci_from_u32() {
         assert_eq!(
             Instruction::from(u32::from_le(0b_0000011_11011_11001_111_10001_1110011)),
             Instruction::CSRRCI {
@@ -1086,6 +1670,19 @@ mod test {
                 imm: 25,
                 csr: 123,
             }
+        );
+    }
+
+    #[test]
+    fn encode_csrrci() {
+        assert_eq!(
+            Instruction::CSRRCI {
+                rd: Register::A7,
+                imm: 25,
+                csr: 123,
+            }
+            .encode(),
+            u32::from_le(0b_0000011_11011_11001_111_10001_1110011),
         );
     }
 }

--- a/src/instructions/rd.rs
+++ b/src/instructions/rd.rs
@@ -10,6 +10,11 @@ impl Rd {
     pub(super) const fn decode(value: u32) -> Register {
         Register::const_from(((value & Self::MASK) >> Self::RSHIFT) as u8)
     }
+
+    #[inline]
+    pub(super) const fn encode(value: Register) -> u32 {
+        ((value as u8) as u32) << Self::RSHIFT
+    }
 }
 
 #[cfg(test)]
@@ -18,8 +23,14 @@ mod test {
     use pretty_assertions::assert_eq;
 
     #[test]
-    fn decode_u32() {
+    fn decode() {
         let instruction = u32::from_le(0b_0100100_01000_01000_101_01000_0010011);
         assert_eq!(Rd::decode(instruction), Register::S0);
+    }
+
+    #[test]
+    fn encode() {
+        let instruction = u32::from_le(0b_0000000_00000_00000_000_01000_0000000);
+        assert_eq!(Rd::encode(Register::S0), instruction);
     }
 }

--- a/src/instructions/rs1.rs
+++ b/src/instructions/rs1.rs
@@ -10,6 +10,11 @@ impl Rs1 {
     pub(super) const fn decode(value: u32) -> Register {
         Register::const_from(((value & Self::MASK) >> Self::RSHIFT) as u8)
     }
+
+    #[inline]
+    pub(super) const fn encode(value: Register) -> u32 {
+        ((value as u8) as u32) << Self::RSHIFT
+    }
 }
 
 #[cfg(test)]
@@ -18,8 +23,14 @@ mod test {
     use pretty_assertions::assert_eq;
 
     #[test]
-    fn decode_u32() {
+    fn decode() {
         let instruction = u32::from_le(0b_0100100_01010_01100_101_01000_0010011);
         assert_eq!(Rs1::decode(instruction), Register::A2);
+    }
+
+    #[test]
+    fn encode() {
+        let instruction = u32::from_le(0b_0000000_00000_01100_000_00000_0000000);
+        assert_eq!(Rs1::encode(Register::A2), instruction);
     }
 }

--- a/src/instructions/rs2.rs
+++ b/src/instructions/rs2.rs
@@ -10,6 +10,11 @@ impl Rs2 {
     pub(super) const fn decode(value: u32) -> Register {
         Register::const_from(((value & Self::MASK) >> Self::RSHIFT) as u8)
     }
+
+    #[inline]
+    pub(super) const fn encode(value: Register) -> u32 {
+        ((value as u8) as u32) << Self::RSHIFT
+    }
 }
 
 #[cfg(test)]
@@ -18,8 +23,14 @@ mod test {
     use pretty_assertions::assert_eq;
 
     #[test]
-    fn decode_u32() {
+    fn decode() {
         let instruction = u32::from_le(0b_0100100_01010_01100_101_01000_0010011);
         assert_eq!(Rs2::decode(instruction), Register::A0);
+    }
+
+    #[test]
+    fn encode() {
+        let instruction = u32::from_le(0b_0000000_01010_00000_000_00000_0000000);
+        assert_eq!(Rs2::encode(Register::A0), instruction);
     }
 }

--- a/src/instructions/shamt.rs
+++ b/src/instructions/shamt.rs
@@ -4,8 +4,14 @@ impl Shamt {
     const MASK: u32 = u32::from_le(0b_0000001_11111_00000_000_00000_0000000);
     const RSHIFT: usize = 20;
 
+    #[inline]
     pub(super) const fn decode(value: u32) -> u8 {
         ((value & Self::MASK) >> Self::RSHIFT) as u8
+    }
+
+    #[inline]
+    pub(super) const fn encode(value: u8) -> u32 {
+        (value as u32) << Self::RSHIFT & Self::MASK
     }
 }
 
@@ -15,11 +21,20 @@ mod test {
     use pretty_assertions::assert_eq;
 
     #[test]
-    fn decode_u32() {
+    fn decode() {
         let instruction = u32::from_le(0b_0100100_00110_01100_101_01000_0010011);
         assert_eq!(Shamt::decode(instruction), 6);
-        // For 64 bit architectures, bit 25 is intepreted as part of the shift amount
+        // For 64 bit architectures, bit 25 is interpreted as part of the shift amount
         let instruction = u32::from_le(0b_0100101_00110_01100_101_01000_0010011);
         assert_eq!(Shamt::decode(instruction), 38);
+    }
+
+    #[test]
+    fn encode() {
+        let instruction = u32::from_le(0b_0000000_00110_00000_000_00000_0000000);
+        assert_eq!(Shamt::encode(6), instruction);
+        // For 64 bit architectures, bit 25 is interpreted as part of the shift amount
+        let instruction = u32::from_le(0b_0000001_00110_00000_000_00000_0000000);
+        assert_eq!(Shamt::encode(38), instruction);
     }
 }

--- a/src/instructions/simmi.rs
+++ b/src/instructions/simmi.rs
@@ -1,8 +1,11 @@
+use crate::integer::i12;
+
 pub(super) struct SImmI;
 
 impl SImmI {
     const U_MASK: u32 = u32::from_le(0b_1111111_00000_00000_000_00000_0000000);
     const L_MASK: u32 = u32::from_le(0b_0000000_00000_00000_000_11111_0000000);
+    const FULL_MASK: u32 = Self::U_MASK + Self::L_MASK;
     const U_RSHIFT: usize = 20;
     const L_RSHIFT: usize = 7;
 
@@ -11,36 +14,71 @@ impl SImmI {
         ((((value & Self::U_MASK) as i32) >> Self::U_RSHIFT)
             + (((value & Self::L_MASK) as i32) >> Self::L_RSHIFT)) as i16
     }
+
+    #[inline]
+    pub(super) const fn encode(value: i16) -> u32 {
+        let trunk = (value & i12::MASK) as u32;
+        ((trunk << Self::U_RSHIFT) + (trunk << Self::L_RSHIFT)) & Self::FULL_MASK
+    }
 }
 
 #[cfg(test)]
 mod test {
-    use crate::integer::i12;
     use pretty_assertions::assert_eq;
 
     use super::*;
 
     #[test]
-    fn decode_u32() {
+    fn decode() {
         let instruction = u32::from_le(0b_0100100_01010_01100_101_01010_0010011);
         assert_eq!(SImmI::decode(instruction), i16::from_le(0b_0100100_01010));
     }
 
     #[test]
-    fn decode_u32_negative_one() {
+    fn decode_negative_one() {
         let instruction = u32::from_le(0b_1111111_11111_01100_101_11111_0010011);
         assert_eq!(SImmI::decode(instruction), -1);
     }
 
     #[test]
-    fn decode_u32_min() {
+    fn decode_min() {
         let instruction = u32::from_le(0b_1000000_01000_01100_101_00000_0010011);
         assert_eq!(SImmI::decode(instruction), i12::MIN);
     }
 
     #[test]
-    fn decode_u32_max() {
+    fn decode_max() {
         let instruction = u32::from_le(0b_0111111_11011_01100_101_11111_0010011);
         assert_eq!(SImmI::decode(instruction), i12::MAX);
+    }
+
+    #[test]
+    fn encode() {
+        let instruction = u32::from_le(0b_0100100_00000_00000_000_01010_0000000);
+        assert_eq!(SImmI::encode(i16::from_le(0b_0100100_01010)), instruction);
+    }
+
+    #[test]
+    fn encode_mask() {
+        let instruction = u32::from_le(0b_0100100_00000_00000_000_01010_0000000);
+        assert_eq!(SImmI::encode(i16::from_le(0b_10100100_01010)), instruction);
+    }
+
+    #[test]
+    fn encode_negative_one() {
+        let instruction = u32::from_le(0b_1111111_00000_00000_000_11111_0000000);
+        assert_eq!(SImmI::encode(-1), instruction);
+    }
+
+    #[test]
+    fn encode_min() {
+        let instruction = u32::from_le(0b_1000000_00000_00000_000_00000_0000000);
+        assert_eq!(SImmI::encode(i12::MIN), instruction);
+    }
+
+    #[test]
+    fn encode_max() {
+        let instruction = u32::from_le(0b_0111111_00000_00000_000_11111_0000000);
+        assert_eq!(SImmI::encode(i12::MAX), instruction);
     }
 }

--- a/src/instructions/types.rs
+++ b/src/instructions/types.rs
@@ -1,0 +1,50 @@
+use crate::registers::Register;
+
+use super::{
+    csr::Csr, csr_imm::CsrImm, immi::ImmI, immu::ImmU, rd::Rd, rs1::Rs1, rs2::Rs2, shamt::Shamt,
+    simmi::SImmI,
+};
+
+pub(super) struct R;
+
+impl R {
+    pub(super) const fn encode(rd: Register, rs1: Register, rs2: Register) -> u32 {
+        Rd::encode(rd) + Rs1::encode(rs1) + Rs2::encode(rs2)
+    }
+}
+
+pub(super) struct I;
+
+impl I {
+    pub(super) const fn encode(rd: Register, rs1: Register, imm: i16) -> u32 {
+        Rd::encode(rd) + Rs1::encode(rs1) + ImmI::encode(imm)
+    }
+
+    pub(super) const fn encode_csr(rd: Register, rs1: Register, csr: u16) -> u32 {
+        Rd::encode(rd) + Rs1::encode(rs1) + Csr::encode(csr)
+    }
+
+    pub(super) const fn encode_csri(rd: Register, imm: u8, csr: u16) -> u32 {
+        Rd::encode(rd) + CsrImm::encode(imm) + Csr::encode(csr)
+    }
+
+    pub(super) const fn encode_shamt(rd: Register, rs1: Register, shamt: u8) -> u32 {
+        Rd::encode(rd) + Rs1::encode(rs1) + Shamt::encode(shamt)
+    }
+}
+
+pub(super) struct U;
+
+impl U {
+    pub(super) const fn encode(rd: Register, imm: i32) -> u32 {
+        Rd::encode(rd) + ImmU::encode(imm)
+    }
+}
+
+pub(super) struct S;
+
+impl S {
+    pub(super) const fn encode(rs1: Register, rs2: Register, simmi: i16) -> u32 {
+        Rs1::encode(rs1) + Rs2::encode(rs2) + SImmI::encode(simmi)
+    }
+}

--- a/src/integer.rs
+++ b/src/integer.rs
@@ -1,6 +1,7 @@
 pub(crate) mod i12 {
     pub const MAX: i16 = 2047;
     pub const MIN: i16 = -2048;
+    pub const MASK: i16 = 0b_0000_1111_1111_1111;
 }
 
 pub(crate) trait AsUnsigned<N> {


### PR DESCRIPTION
This PR makes it possible to encode instructions to binary. Built on top of #23 which should be merged first

- Add encode functions to instruction parts
- Remove unnecessary masking in decode functions
- Add encode function for instruction
