### PR TITLE
Improve documentation

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,0 +1,51 @@
+name: Deploy Crate Documentation
+
+on:
+  push:
+    branches: ["master"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+env:
+  DOC_DIR: ./doc
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+      - name: Setup Pages
+        uses: actions/configure-pages@v2
+      - name: Build docs
+        run: |
+          cargo doc --document-private-items
+          rm -rf $DOC_DIR
+          echo "<meta http-equiv=\"refresh\" content=\"0; url=tiptop\">" > target/doc/index.html
+          cp -r target/doc $DOC_DIR
+      - name: Fix file permissions
+        # To fix file permissions issue: https://github.com/actions/deploy-pages/issues/188
+        run: chmod -c -R +rX $DOC_DIR
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          # Upload entire repository
+          path: ${{ env.DOC_DIR }}
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/src/csr.rs
+++ b/src/csr.rs
@@ -1,3 +1,9 @@
+//! Control status registers
+//!
+//! Control and status register (CSR) is a register that stores various
+//! information in CPU. RISC-V defines a separate address space of 4096 CSRs.
+//! The RISC-V specification only explicitly allocates a part of address space
+//! the rest is OS - implementations specific.
 use std::sync::atomic::{AtomicI32, AtomicI64, Ordering::SeqCst};
 
 /// According to the RISC-V specification, the number of control status registers.
@@ -5,6 +11,13 @@ const CSR_SIZE: usize = 4096;
 
 /// The control status registers.
 pub trait ControlStatusRegisters {
+    /// The type of the processor's registers.
+    ///
+    /// Usually, this one of the following
+    ///
+    /// * i32 (for RV32I or RV32E)
+    /// * i64 (for RV64I)
+    /// * i128 (for RV128I)
     type Register;
     /// Reads the value of the CSR.
     ///
@@ -43,6 +56,7 @@ pub trait ControlStatusRegisters {
 ///
 /// Additionally some registers are read only.
 pub struct CSR32 {
+    /// A boxed slice of the CSR registers.
     registers: Box<[AtomicI32]>,
 }
 
@@ -65,6 +79,7 @@ pub struct CSR32 {
 ///
 /// Additionally some registers are read only.
 pub struct CSR64 {
+    /// A boxed slice of the CSR registers.
     registers: Box<[AtomicI64]>,
 }
 

--- a/src/instruction_set.rs
+++ b/src/instruction_set.rs
@@ -1,9 +1,26 @@
+//! A trait that encapsulates the core behaviour of an instruction set.
+//!
+//! RISC-V defines a number of base instructions sets (RV32I, RV32E, RV64I, and
+//! RV128I) and additional extensions such as M, A, F D, Q, L, C, B, J, T, P, V,
+//! or N. This is not a exhaustive list since RISC-V is designed to extensible.
+//!
+//! To encapsulate this extensibility the [InstructionSet] trait captures the
+//! core concept and behaviour of an instruction set.
+//!
+//! The intention of this crate is to initially provide the implementations of
+//! some of the base instructions sets. However to enable alternative
+//! implementations and extensions, this trait can be implemented.
 use std::fmt::Display;
 
 use crate::{csr::ControlStatusRegisters, processor::Processor};
 
+/// A processor exception
+///
+/// Different instructions can raise exceptions in the processor for system
+/// interrupt.
 #[derive(Debug)]
 pub enum Exception {
+    /// The processor exception raised when an instruction is not recognised.
     UnimplementedInstruction(u32),
 }
 
@@ -18,8 +35,22 @@ impl Display for Exception {
     }
 }
 
+/// The core behaviour of an instruction set.
 pub trait InstructionSet: Sized {
+    /// The type of the processor's registers.
+    ///
+    /// Usually, this one of the following
+    ///
+    /// * i32 (for RV32I or RV32E)
+    /// * i64 (for RV64I)
+    /// * i128 (for RV128I)
     type RegisterType;
+
+    /// The type of the processors CSRs.
+    ///
+    /// Usually,
+    /// * [crate::csr::CSR32] for a 32-BIT architecture
+    /// * [crate::csr::CSR64] for a 64-BIT architecture
     type CSRType: ControlStatusRegisters<Register = Self::RegisterType>;
 
     /// Decode this 32-bit value as an instruction. TODO: handle larger instructions
@@ -28,6 +59,7 @@ pub trait InstructionSet: Sized {
     /// Encode the instruction to bytes. TODO: handle larger instructions
     fn encode(self) -> u32;
 
+    /// Run this instruction on the provided processor.
     fn execute(
         self,
         processor: &mut Processor<Self::RegisterType, Self::CSRType>,
@@ -37,6 +69,19 @@ pub trait InstructionSet: Sized {
     fn instruction_size(&self) -> usize {
         4
     }
+}
 
-    const SHIFT_MASK: Self::RegisterType;
+#[cfg(test)]
+mod test {
+    use super::*;
+    #[test]
+    fn test_exception_display() {
+        let exception = Exception::UnimplementedInstruction(u32::from_le(
+            0b_00001000_00000100_00000010_00000001,
+        ));
+        assert_eq!(
+            exception.to_string(),
+            "The given instruction is not yet implemented 0b00001000000001000000001000000001"
+        )
+    }
 }

--- a/src/instructions/csr.rs
+++ b/src/instructions/csr.rs
@@ -1,17 +1,25 @@
+//! A module including helpers for extracting the `CSR` address out of a `CSR` instruction.
+
+/// For extraction the `CSR` address out of a `CSR` instruction.
 pub(super) struct Csr;
 
 impl Csr {
-    /// This is useful as a reference but not actually required for extracting this part of the
-    /// instruction
+    /// The bit mask for the relevant bits in the instruction.
+    ///
+    /// _Note_: this is provided here as a reference since it is not actually
+    /// required for extracting this value from the instruction.
     #[allow(unused)]
     const MASK: u32 = u32::from_le(0b_1111111_11111_00000_000_00000_0000000);
+    /// The right shift to apply to the instruction to extract the CSR value.
     const RSHIFT: usize = 20;
 
+    /// Decode the `CSR` address from a `CSR` instruction.
     #[inline]
     pub(super) const fn decode(value: u32) -> u16 {
         (value >> Self::RSHIFT) as u16
     }
 
+    /// Encode the `CSR` address into a `CSR` instruction.
     #[inline]
     pub(super) const fn encode(value: u16) -> u32 {
         (value as u32) << Self::RSHIFT

--- a/src/instructions/csr_imm.rs
+++ b/src/instructions/csr_imm.rs
@@ -1,14 +1,23 @@
+//! A module including helpers for extracting the 5-bit immediate value out of
+//! a `CSR` instruction.
+
+/// For extracting the 5-bit immediate value out of a `CSR` instruction.
 pub(super) struct CsrImm;
 
 impl CsrImm {
+    /// The bit mask for extracting the relevant bits out of the instruction.
     const MASK: u32 = u32::from_le(0b_0000000_00000_11111_000_00000_0000000);
+    /// The right shift to apply to the instruction to after extracting the
+    /// relevant bits.
     const RSHIFT: usize = 15;
 
+    /// Decode the 5-bit immediate value from a `CSR` instruction.
     #[inline]
     pub(super) const fn decode(value: u32) -> u8 {
         ((value & Self::MASK) >> Self::RSHIFT) as u8
     }
 
+    /// Encode the 5-bit immediate value into a `CSR` instruction.
     #[inline]
     pub(super) const fn encode(value: u8) -> u32 {
         (value as u32) << Self::RSHIFT & Self::MASK

--- a/src/instructions/funct3.rs
+++ b/src/instructions/funct3.rs
@@ -1,17 +1,20 @@
+//! A module including helpers for extracting the 3-bit `Funct3` value out of
+//! an instruction.
+
+/// For extracting the 3-bit `Funct3` value out of a instruction.
 pub(super) struct Funct3;
 
 impl Funct3 {
+    /// The bit mask for extracting the relevant bits out of the instruction.
     const MASK: u32 = u32::from_le(0b_0000000_00000_00000_111_00000_0000000);
+    /// The right shift to apply to the instruction to after extracting the
+    /// relevant bits.
     const RSHIFT: usize = 12;
 
+    /// Decode the 3-bit `Funct3` value from a CSR instruction.
     #[inline]
     pub(super) const fn decode(value: u32) -> u8 {
         ((value & Self::MASK) >> Self::RSHIFT) as u8
-    }
-
-    #[inline]
-    pub(super) const fn encode(value: u8) -> u32 {
-        (value as u32) << Self::RSHIFT & Self::MASK
     }
 }
 
@@ -24,17 +27,5 @@ mod test {
     fn decode() {
         let instruction = u32::from_le(0b_0100100_01000_01000_101_00000_0010011);
         assert_eq!(Funct3::decode(instruction), 0b_101);
-    }
-
-    #[test]
-    fn encode() {
-        let instruction = u32::from_le(0b_0000000_00000_00000_101_00000_0000000);
-        assert_eq!(Funct3::encode(0b_101), instruction);
-    }
-
-    #[test]
-    fn encode_mask() {
-        let instruction = u32::from_le(0b_0000000_00000_00000_001_00000_0000000);
-        assert_eq!(Funct3::encode(0b_1001), instruction);
     }
 }

--- a/src/instructions/funct6.rs
+++ b/src/instructions/funct6.rs
@@ -1,22 +1,27 @@
-/// On 64-bit architectures, bit 25 is part of the shift amount - hence rather than having a funct7,
-/// we have a funct6
+//! A module including helpers for extracting the 6-bit `Funct6` value out of
+//! an instruction.
+
+/// For extracting the 6-bit `Funct6` value out of an instruction.
+///
+/// _Note_: On 64-bit architectures, bit 25 is part of the shift amount for
+/// the shift immediate instructions. Hence rather than using `Funct7` which would
+/// include bit 25, we define a `Funct6`.
 pub(super) struct Funct6;
 
 impl Funct6 {
-    /// This is useful as a reference but not actually required for extracting this part of the
-    /// instruction
+    /// The bit mask for the relevant bits in the instruction.
+    ///
+    /// _Note_: this is provided here as a reference since it is not actually
+    /// required for extracting this value from the instruction.
     #[allow(unused)]
     const MASK: u32 = u32::from_le(0b_1111110_00000_00000_000_00000_0000000);
+    /// The right shift to apply to the instruction to extract the CSR value.
     const RSHIFT: usize = 26;
 
+    /// Decode the 6-bit `Funct6` value from an instruction.
     #[inline]
     pub(super) const fn decode(value: u32) -> u8 {
         (value >> Self::RSHIFT) as u8
-    }
-
-    #[inline]
-    pub(super) const fn encode(value: u8) -> u32 {
-        (value as u32) << Self::RSHIFT
     }
 }
 
@@ -29,17 +34,5 @@ mod test {
     fn decode() {
         let instruction = u32::from_le(0b_0100100_01000_01000_101_00000_0010011);
         assert_eq!(Funct6::decode(instruction), 0b_010010);
-    }
-
-    #[test]
-    fn encode() {
-        let instruction = u32::from_le(0b_0100100_00000_00000_000_00000_0000000);
-        assert_eq!(Funct6::encode(0b_010010), instruction);
-    }
-
-    #[test]
-    fn encode_mask() {
-        let instruction = u32::from_le(0b_0110100_00000_00000_000_00000_0000000);
-        assert_eq!(Funct6::encode(0b_1011010), instruction);
     }
 }

--- a/src/instructions/funct7.rs
+++ b/src/instructions/funct7.rs
@@ -1,20 +1,23 @@
+//! A module including helpers for extracting the 7-bit `Funct7` value out of
+//! an instruction.
+
+/// For extracting the 7-bit `Funct7` value out of an instruction.
 pub(super) struct Funct7;
 
 impl Funct7 {
-    /// This is useful as a reference but not actually required for extracting this part of the
-    /// instruction
+    /// The bit mask for the relevant bits in the instruction.
+    ///
+    /// _Note_: this is provided here as a reference since it is not actually
+    /// required for extracting this value from the instruction.
     #[allow(unused)]
     const MASK: u32 = u32::from_le(0b_1111111_00000_00000_000_00000_0000000);
+    /// The right shift to apply to the instruction to extract the CSR value.
     const RSHIFT: usize = 25;
 
+    /// Decode the 7-bit `Funct7` value from an instruction.
     #[inline]
     pub(super) const fn decode(value: u32) -> u8 {
         (value >> Self::RSHIFT) as u8
-    }
-
-    #[inline]
-    pub(super) const fn encode(value: u8) -> u32 {
-        (value as u32) << Self::RSHIFT
     }
 }
 
@@ -27,17 +30,5 @@ mod test {
     fn decode() {
         let instruction = u32::from_le(0b_0100100_01000_01000_101_00000_0010011);
         assert_eq!(Funct7::decode(instruction), 0b_0100100);
-    }
-
-    #[test]
-    fn encode() {
-        let instruction = u32::from_le(0b_0100100_00000_00000_000_00000_0000000);
-        assert_eq!(Funct7::encode(0b_0100100), instruction);
-    }
-
-    #[test]
-    fn encode_mask() {
-        let instruction = u32::from_le(0b_0110100_00000_00000_000_00000_0000000);
-        assert_eq!(Funct7::encode(0b_10110100), instruction);
     }
 }

--- a/src/instructions/immi.rs
+++ b/src/instructions/immi.rs
@@ -1,17 +1,26 @@
+//! A module including helpers for extracting the 12-bit signed immediate value
+//! out of an instruction.
+
+/// For extracting the 12-bit signed immediate value out of an instruction.
 pub(super) struct ImmI;
 
 impl ImmI {
-    /// This is useful as a reference but not actually required for extracting this part of the
-    /// instruction
+    /// The bit mask for the relevant bits in the instruction.
+    ///
+    /// _Note_: this is provided here as a reference since it is not actually
+    /// required for extracting this value from the instruction.
     #[allow(unused)]
     const MASK: u32 = u32::from_le(0b_1111111_11111_00000_000_00000_0000000);
+    /// The right shift to apply to the instruction to extract the immediate value.
     const RSHIFT: usize = 20;
 
+    /// Decode the 12-bit signed immediate value from an instruction.
     #[inline]
     pub(super) const fn decode(value: u32) -> i16 {
         ((value as i32) >> Self::RSHIFT) as i16
     }
 
+    /// Encode the 12-bit signed immediate value into an instruction.
     #[inline]
     pub(super) const fn encode(value: i16) -> u32 {
         (value as u32) << Self::RSHIFT

--- a/src/instructions/immu.rs
+++ b/src/instructions/immu.rs
@@ -1,17 +1,26 @@
+//! A module including helpers for extracting the 20-bit signed immediate value
+//! out of an instruction.
+
+/// For extracting the 20-bit signed immediate value out of an instruction.
 pub(super) struct ImmU;
 
 impl ImmU {
-    /// This is useful as a reference but not actually required for extracting this part of the
-    /// instruction
+    /// The bit mask for the relevant bits in the instruction.
+    ///
+    /// _Note_: this is provided here as a reference since it is not actually
+    /// required for extracting this value from the instruction.
     #[allow(unused)]
     pub(super) const MASK: u32 = u32::from_le(0b_1111111_11111_11111_111_00000_0000000);
+    /// The right shift to apply to the instruction to extract the immediate value.
     pub(super) const RSHIFT: usize = 12;
 
+    /// Decode the 20-bit signed immediate value from an instruction.
     #[inline]
     pub(super) const fn decode(value: u32) -> i32 {
         (value >> Self::RSHIFT) as i32
     }
 
+    /// Encode the 20-bit signed immediate value into an instruction.
     #[inline]
     pub(super) const fn encode(value: i32) -> u32 {
         (value as u32) << Self::RSHIFT

--- a/src/instructions/impl_instruction_set.rs
+++ b/src/instructions/impl_instruction_set.rs
@@ -1,3 +1,5 @@
+//! The implementation of [crate::instruction_set::InstructionSet] for
+//! [crate::instructions::Instruction].
 use crate::csr::{ControlStatusRegisters, CSR32};
 use crate::instruction_set::{Exception, InstructionSet};
 use crate::integer::{AsSigned, AsUnsigned};
@@ -6,9 +8,12 @@ use crate::registers::Register;
 
 use super::Instruction;
 
-impl InstructionSet for Instruction {
+impl Instruction {
+    /// A bit mask apply to a register before being used as the shift amount.
     const SHIFT_MASK: i32 = 0b_00000000_00000000_00000000_00011111;
+}
 
+impl InstructionSet for Instruction {
     type RegisterType = i32;
     type CSRType = CSR32;
 

--- a/src/instructions/mod.rs
+++ b/src/instructions/mod.rs
@@ -1,3 +1,10 @@
+//! Types representing RISC-V instructions.
+//!
+//! [Instruction] is primarily the definition of the RV32I instructions and
+//! [crate::instruction_set::InstructionSet] has been implemented for it.
+//!
+//! This module also contains a number of helpers for exacting the different part of
+//! an encoded instruction.
 #![allow(clippy::unusual_byte_groupings, clippy::upper_case_acronyms)]
 mod csr;
 mod csr_imm;
@@ -35,7 +42,12 @@ pub(super) enum Instruction {
     /// top 20 bits of the destination register rd, filling in the lowest 12 bits with zeros.
     ///
     /// `rd <- sext(immediate[31:12] << 12)`
-    LUI { rd: Register, imm: i32 },
+    LUI {
+        /// The destination register
+        rd: Register,
+        /// The 20-bit immediate value sign extended to an [i32].
+        imm: i32,
+    },
 
     /// # Add upper immediate to programme counter
     ///
@@ -44,7 +56,12 @@ pub(super) enum Instruction {
     /// pc, then places the result in register rd.
     ///
     /// `rd <- pc + sext(immediate[31:12] << 12)`
-    AUIPC { rd: Register, imm: i32 },
+    AUIPC {
+        /// The destination register
+        rd: Register,
+        /// The 20-bit immediate value sign extended to an [i32].
+        imm: i32,
+    },
 
     /// # Add Immediate
     ///
@@ -52,10 +69,13 @@ pub(super) enum Instruction {
     /// the result is simply the low XLEN bits of the result. ADDI rd, rs1, 0 is used to implement
     /// the MV rd, rs1 assembler pseudo-instruction.
     ///
-    /// `rd <- rs1 + rs2`
+    /// `rd <- rs1 + sext(immediate)`
     ADDI {
+        /// The destination register.
         rd: Register,
+        /// Source register 1.
         rs1: Register,
+        /// The 12-bit immediate value sign extended to an [i16].
         imm: i16,
     },
 
@@ -66,8 +86,11 @@ pub(super) enum Instruction {
     ///
     /// `rd <- rs1 <s sext(immediate)`
     SLTI {
+        /// The destination register
         rd: Register,
+        /// Source register 1.
         rs1: Register,
+        /// The 12-bit immediate value sign extended to an [i16].
         imm: i16,
     },
 
@@ -78,8 +101,11 @@ pub(super) enum Instruction {
     ///
     /// `rd <- rs1 <u sext(immediate)`
     SLTIU {
+        /// The destination register
         rd: Register,
+        /// Source register 1.
         rs1: Register,
+        /// The 12-bit immediate value sign extended to an [i16].
         imm: i16,
     },
 
@@ -93,8 +119,11 @@ pub(super) enum Instruction {
     ///
     /// `rd <- rs1 ^ sext(immediate)`
     XORI {
+        /// The destination register
         rd: Register,
+        /// Source register 1.
         rs1: Register,
+        /// The 12-bit immediate value sign extended to an [i16].
         imm: i16,
     },
 
@@ -104,8 +133,11 @@ pub(super) enum Instruction {
     ///
     /// `rd <- rs1 | sext(immediate)`
     ORI {
+        /// The destination register
         rd: Register,
+        /// Source register 1.
         rs1: Register,
+        /// The 12-bit immediate value sign extended to an [i16].
         imm: i16,
     },
 
@@ -116,8 +148,11 @@ pub(super) enum Instruction {
     ///
     /// `rd <- rs1 & sext(immediate)`
     ANDI {
+        /// The destination register
         rd: Register,
+        /// Source register 1.
         rs1: Register,
+        /// The 12-bit immediate value sign extended to an [i16].
         imm: i16,
     },
 
@@ -129,8 +164,13 @@ pub(super) enum Instruction {
     ///
     /// `rd <- rs1 << shamt`
     SLLI {
+        /// The destination register
         rd: Register,
+        /// Source register 1.
         rs1: Register,
+        /// The 5-bit (for 32-bit architecture) shift amount zero extened to a [u8].
+        ///
+        /// Note: on 64-bit this will be a 6-bit value.
         shamt: u8,
     },
 
@@ -142,8 +182,13 @@ pub(super) enum Instruction {
     ///
     /// `rd <- rs1 >>u shamt`
     SRLI {
+        /// The destination register
         rd: Register,
+        /// Source register 1.
         rs1: Register,
+        /// The 5-bit (for 32-bit architecture) shift amount zero extened to a [u8].
+        ///
+        /// Note: on 64-bit this will be a 6-bit value.
         shamt: u8,
     },
 
@@ -155,8 +200,13 @@ pub(super) enum Instruction {
     ///
     /// `rd <- rs1 >>s shamt`
     SRAI {
+        /// The destination register
         rd: Register,
+        /// Source register 1.
         rs1: Register,
+        /// The 5-bit (for 32-bit architecture) shift amount zero extened to a [u8].
+        ///
+        /// Note: on 64-bit this will be a 6-bit value.
         shamt: u8,
     },
 
@@ -168,8 +218,11 @@ pub(super) enum Instruction {
     ///
     /// `rd <- rs1 + rs2`
     ADD {
+        /// The destination register
         rd: Register,
+        /// Source register 1.
         rs1: Register,
+        /// Source register 2.
         rs2: Register,
     },
 
@@ -181,20 +234,26 @@ pub(super) enum Instruction {
     ///
     /// `rd <- rs1 - rs2`
     SUB {
+        /// The destination register
         rd: Register,
+        /// Source register 1.
         rs1: Register,
+        /// Source register 2.
         rs2: Register,
     },
 
     /// # Shift Left Logical
     ///
     /// Performs logical left shift on the value in register rs1 by the shift amount held in the
-    /// lower 5 bits (for 32-bit archeticture) or 6 bits (64-bit archetecture) of register rs2.
+    /// lower 5 bits (for 32-bit architecture) or 6 bits (64-bit archetecture) of register rs2.
     ///
     /// `rd = rs1 << rs2`
     SLL {
+        /// The destination register
         rd: Register,
+        /// Source register 1.
         rs1: Register,
+        /// Source register 2.
         rs2: Register,
     },
 
@@ -205,8 +264,11 @@ pub(super) enum Instruction {
     ///
     /// `rd <- rs1 <s rs2`
     SLT {
+        /// The destination register
         rd: Register,
+        /// Source register 1.
         rs1: Register,
+        /// Source register 2.
         rs2: Register,
     },
 
@@ -217,8 +279,11 @@ pub(super) enum Instruction {
     ///
     /// `rd <- rs1 <u rs2`
     SLTU {
+        /// The destination register
         rd: Register,
+        /// Source register 1.
         rs1: Register,
+        /// Source register 2.
         rs2: Register,
     },
 
@@ -228,32 +293,41 @@ pub(super) enum Instruction {
     ///
     /// `rd = rs1 ^ rs2`
     XOR {
+        /// The destination register
         rd: Register,
+        /// Source register 1.
         rs1: Register,
+        /// Source register 2.
         rs2: Register,
     },
 
     /// # Shift Right Logical
     ///
     /// Performs logical right shift on the value in register rs1 by the shift amount held in the
-    /// lower 5 bits (for 32-bit archeticture) or 6 bits (64-bit archetecture) of register rs2.
+    /// lower 5 bits (for 32-bit architecture) or 6 bits (64-bit archetecture) of register rs2.
     ///
     /// `rd = rs1 >> rs2`
     SRL {
+        /// The destination register
         rd: Register,
+        /// Source register 1.
         rs1: Register,
+        /// Source register 2.
         rs2: Register,
     },
 
     /// # Shift Right Arithmetic
     ///
     /// Performs arithmetic right shift on the value in register rs1 by the shift amount held in the
-    /// lower 5 bits (for 32-bit archeticture) or 6 bits (64-bit archetecture) of register rs2.
+    /// lower 5 bits (for 32-bit architecture) or 6 bits (64-bit archetecture) of register rs2.
     ///
     /// `rd = rs1 >>s rs2`
     SRA {
+        /// The destination register
         rd: Register,
+        /// Source register 1.
         rs1: Register,
+        /// Source register 2.
         rs2: Register,
     },
 
@@ -263,8 +337,11 @@ pub(super) enum Instruction {
     ///
     /// `rd = rs1 | rs2`
     OR {
+        /// The destination register
         rd: Register,
+        /// Source register 1.
         rs1: Register,
+        /// Source register 2.
         rs2: Register,
     },
 
@@ -274,8 +351,11 @@ pub(super) enum Instruction {
     ///
     /// `rd = rs1 & rs2`
     AND {
+        /// The destination register
         rd: Register,
+        /// Source register 1.
         rs1: Register,
+        /// Source register 2.
         rs2: Register,
     },
 
@@ -286,8 +366,11 @@ pub(super) enum Instruction {
     ///
     /// `rd <- sext(M[rs1 + sext(offset)][7:0])`
     LB {
+        /// The destination register
         rd: Register,
+        /// Source register 1.
         rs1: Register,
+        /// The 12-bit offset value sign-extended to an [i16].
         offset: i16,
     },
 
@@ -298,8 +381,11 @@ pub(super) enum Instruction {
     ///
     /// `rd <- sext(M[rs1 + sext(offset)][15:0])`
     LH {
+        /// The destination register
         rd: Register,
+        /// Source register 1.
         rs1: Register,
+        /// The 12-bit offset value sign-extended to an [i16].
         offset: i16,
     },
 
@@ -310,8 +396,11 @@ pub(super) enum Instruction {
     ///
     /// `rd <- sext(M[rs1 + sext(offset)][31:0])`
     LW {
+        /// The destination register
         rd: Register,
+        /// Source register 1.
         rs1: Register,
+        /// The 12-bit offset value sign-extended to an [i16].
         offset: i16,
     },
 
@@ -322,8 +411,11 @@ pub(super) enum Instruction {
     ///
     /// `rd <- M[rs1 + sext(offset)][7:0]`
     LBU {
+        /// The destination register
         rd: Register,
+        /// Source register 1.
         rs1: Register,
+        /// The 12-bit offset value sign-extended to an [i16].
         offset: i16,
     },
 
@@ -334,8 +426,11 @@ pub(super) enum Instruction {
     ///
     /// `rd <- M[rs1 + sext(offset)][15:0]`
     LHU {
+        /// The destination register
         rd: Register,
+        /// Source register 1.
         rs1: Register,
+        /// The 12-bit offset value sign-extended to an [i16].
         offset: i16,
     },
 
@@ -345,8 +440,11 @@ pub(super) enum Instruction {
     ///
     /// `M[rs1 + sext(offset)] = rs2[7:0]`
     SB {
+        /// Source register 1.
         rs1: Register,
+        /// Source register 2.
         rs2: Register,
+        /// The 12-bit offset value sign-extended to an [i16].
         offset: i16,
     },
 
@@ -356,8 +454,11 @@ pub(super) enum Instruction {
     ///
     /// `M[rs1 + sext(offset)] = rs2[15:0]`
     SH {
+        /// Source register 1.
         rs1: Register,
+        /// Source register 2.
         rs2: Register,
+        /// The 12-bit offset value sign-extended to an [i16].
         offset: i16,
     },
 
@@ -367,8 +468,11 @@ pub(super) enum Instruction {
     ///
     /// `M[rs1 + sext(offset)] = rs2[31:0]`
     SW {
+        /// Source register 1.
         rs1: Register,
+        /// Source register 2.
         rs2: Register,
+        /// The 12-bit offset value sign-extended to an [i16].
         offset: i16,
     },
 
@@ -383,8 +487,11 @@ pub(super) enum Instruction {
     ///
     /// `t = CSRs[csr]; CSRs[csr] = rs1; rd = t`
     CSRRW {
+        /// The destination register
         rd: Register,
+        /// Source register 1.
         rs1: Register,
+        /// The 12-bit csr address value zero-extended to an [u16].
         csr: u16,
     },
 
@@ -399,8 +506,11 @@ pub(super) enum Instruction {
     ///
     /// `t = CSRs[csr]; CSRs[csr] = t | rs1; rd = t`
     CSRRS {
+        /// The destination register
         rd: Register,
+        /// Source register 1.
         rs1: Register,
+        /// The 12-bit csr address value zero-extended to an [u16].
         csr: u16,
     },
 
@@ -415,8 +525,11 @@ pub(super) enum Instruction {
     ///
     /// `t = CSRs[csr]; CSRs[csr] = t & ∼rs1; rd = t`
     CSRRC {
+        /// The destination register
         rd: Register,
+        /// Source register 1.
         rs1: Register,
+        /// The 12-bit csr address value zero-extended to an [u16].
         csr: u16,
     },
 
@@ -426,7 +539,14 @@ pub(super) enum Instruction {
     /// 5-bit unsigned immediate (`uimm[4:0]`) field encoded in the rs1 field.
     ///
     /// `rd = CSRs[csr]; CSRs[csr] = zext(imm)`
-    CSRRWI { rd: Register, csr: u16, imm: u8 },
+    CSRRWI {
+        /// The destination register
+        rd: Register,
+        /// The 12-bit csr address value zero-extended to an [u16].
+        csr: u16,
+        /// The 5-bit immediate value zero-extended to a [u8].
+        imm: u8,
+    },
 
     /// # Atomic CSR read set immediate
     ///
@@ -434,7 +554,14 @@ pub(super) enum Instruction {
     /// unsigned immediate (`uimm[4:0]`) field encoded in the rs1 field.
     ///
     /// `t = CSRs[csr]; CSRs[csr] = t | zext(imm); rd = t`
-    CSRRSI { rd: Register, csr: u16, imm: u8 },
+    CSRRSI {
+        /// The destination register
+        rd: Register,
+        /// The 12-bit csr address value zero-extended to an [u16].
+        csr: u16,
+        /// The 5-bit immediate value zero-extended to a [u8].
+        imm: u8,
+    },
 
     /// # Atomic CSR read clear immediate
     ///
@@ -442,10 +569,22 @@ pub(super) enum Instruction {
     /// 5-bit unsigned immediate (`uimm[4:0]`) field encoded in the rs1 field.
     ///
     /// `t = CSRs[csr]; CSRs[csr] = t & ~zext(imm); rd = t`
-    CSRRCI { rd: Register, csr: u16, imm: u8 },
+    CSRRCI {
+        /// The destination register
+        rd: Register,
+        /// The 12-bit csr address value zero-extended to an [u16].
+        csr: u16,
+        /// The 5-bit immediate value zero-extended to a [u8].
+        imm: u8,
+    },
 }
 
 impl Instruction {
+    /// Decode a [u32] as an [Instruction].
+    ///
+    /// Instructions in RISC-V are encoded using little endian byte order.
+    /// Therefore, to avoid unexpected results, ensure the [u32] is little endian.
+    #[inline]
     const fn decode(value: u32) -> Result<Self, Exception> {
         let instruction = match Instruction::op_code(value) {
             0b_0110111 => Instruction::LUI {
@@ -644,6 +783,8 @@ impl Instruction {
         Ok(instruction)
     }
 
+    /// Encode an [Instruction] as a little endian [u32].
+    #[inline]
     pub(crate) const fn encode(self) -> u32 {
         match self {
             Instruction::LUI { rd, imm } => {
@@ -796,12 +937,14 @@ impl TryFrom<u32> for Instruction {
 }
 
 impl Instruction {
+    /// Extract the op code from the [u32].
     #[inline]
     const fn op_code(value: u32) -> u8 {
         (value & OPP_MASK) as u8
     }
 }
 
+/// The bit mask to extract the instructions op code from a [u32].
 const OPP_MASK: u32 = u32::from_le(0b_0000000_00000_00000_000_00000_1111111);
 
 #[cfg(test)]

--- a/src/instructions/rd.rs
+++ b/src/instructions/rd.rs
@@ -1,16 +1,24 @@
+//! A module including helpers for extracting the destination register out of
+//! an instruction.
 use crate::registers::Register;
 
+/// For extracting the destination register out of an instruction.
 pub(super) struct Rd;
 
 impl Rd {
+    /// The bit mask for extracting the relevant bits out of the instruction.
     const MASK: u32 = u32::from_le(0b_0000000_00000_00000_000_11111_0000000);
+    /// The right shift to apply to the instruction to after extracting the
+    /// relevant bits.
     const RSHIFT: usize = 7;
 
+    /// Decode the destination register from an instruction.
     #[inline]
     pub(super) const fn decode(value: u32) -> Register {
         Register::const_from(((value & Self::MASK) >> Self::RSHIFT) as u8)
     }
 
+    /// Encode the destination register into an instruction.
     #[inline]
     pub(super) const fn encode(value: Register) -> u32 {
         ((value as u8) as u32) << Self::RSHIFT

--- a/src/instructions/rs1.rs
+++ b/src/instructions/rs1.rs
@@ -1,16 +1,24 @@
+//! A module including helpers for extracting source register 1 out of
+//! an instruction.
 use crate::registers::Register;
 
+/// For extracting source register 1 out of an instruction.
 pub(super) struct Rs1;
 
 impl Rs1 {
+    /// The bit mask for extracting the relevant bits out of the instruction.
     const MASK: u32 = u32::from_le(0b_0000000_00000_11111_000_00000_0000000);
+    /// The right shift to apply to the instruction to after extracting the
+    /// relevant bits.
     const RSHIFT: usize = 15;
 
+    /// Decode source register 1 from an instruction.
     #[inline]
     pub(super) const fn decode(value: u32) -> Register {
         Register::const_from(((value & Self::MASK) >> Self::RSHIFT) as u8)
     }
 
+    /// Encode source register 1 into an instruction.
     #[inline]
     pub(super) const fn encode(value: Register) -> u32 {
         ((value as u8) as u32) << Self::RSHIFT

--- a/src/instructions/rs2.rs
+++ b/src/instructions/rs2.rs
@@ -1,16 +1,24 @@
+//! A module including helpers for extracting source register 2 out of
+//! an instruction.
 use crate::registers::Register;
 
+/// For extracting source register 2 out of an instruction.
 pub(super) struct Rs2;
 
 impl Rs2 {
+    /// The bit mask for extracting the relevant bits out of the instruction.
     const MASK: u32 = u32::from_le(0b_0000000_11111_00000_000_00000_0000000);
+    /// The right shift to apply to the instruction to after extracting the
+    /// relevant bits.
     const RSHIFT: usize = 20;
 
+    /// Decode source register 2 from an instruction.
     #[inline]
     pub(super) const fn decode(value: u32) -> Register {
         Register::const_from(((value & Self::MASK) >> Self::RSHIFT) as u8)
     }
 
+    /// Encode source register 2 into an instruction.
     #[inline]
     pub(super) const fn encode(value: Register) -> u32 {
         ((value as u8) as u32) << Self::RSHIFT

--- a/src/instructions/shamt.rs
+++ b/src/instructions/shamt.rs
@@ -1,14 +1,25 @@
+//! A module including helpers for extracting the 5-bit (or 6-bit) shift amount
+//! out of an instruction.
+
+/// For extracting the 5-bit (or 6-bit) shift amount out of an instruction.
+///
+/// _Note_: On 64-bit architectures, bit 25 is part of the shift amount.
 pub(super) struct Shamt;
 
 impl Shamt {
+    /// The bit mask for extracting the relevant bits out of the instruction.
     const MASK: u32 = u32::from_le(0b_0000001_11111_00000_000_00000_0000000);
+    /// The right shift to apply to the instruction to after extracting the
+    /// relevant bits.
     const RSHIFT: usize = 20;
 
+    /// Decode the 5-bit (or 6-bit) shift amount from an instruction.
     #[inline]
     pub(super) const fn decode(value: u32) -> u8 {
         ((value & Self::MASK) >> Self::RSHIFT) as u8
     }
 
+    /// Encode the 5-bit (or 6-bit) shift amount to an instruction.
     #[inline]
     pub(super) const fn encode(value: u8) -> u32 {
         (value as u32) << Self::RSHIFT & Self::MASK

--- a/src/instructions/simmi.rs
+++ b/src/instructions/simmi.rs
@@ -1,20 +1,30 @@
+//! A module including helpers for extracting the 12-bit immediate value out of
+//! an `S`-type instruction.
 use crate::integer::i12;
 
+/// For extracting the 12-bit immediate value out of an `S`-type instruction.
 pub(super) struct SImmI;
 
 impl SImmI {
+    /// The bit mask for extracting the upper 7 bits of the immediate value.
     const U_MASK: u32 = u32::from_le(0b_1111111_00000_00000_000_00000_0000000);
+    /// The bit mask for extracting the lower 5 bits of the immediate value
     const L_MASK: u32 = u32::from_le(0b_0000000_00000_00000_000_11111_0000000);
+    /// The bit mask of all the relevant bits of the instruction.
     const FULL_MASK: u32 = Self::U_MASK + Self::L_MASK;
+    /// The right shift to apply to the upper 7 bits.
     const U_RSHIFT: usize = 20;
+    /// The right shift to apply to the lower 5 bits.
     const L_RSHIFT: usize = 7;
 
+    /// Decode the 12-bit immediate value from an `S`-type instruction.
     #[inline]
     pub(super) const fn decode(value: u32) -> i16 {
         ((((value & Self::U_MASK) as i32) >> Self::U_RSHIFT)
             + (((value & Self::L_MASK) as i32) >> Self::L_RSHIFT)) as i16
     }
 
+    /// Encdoe the 12-bit immediate value into an `S`-type instruction.
     #[inline]
     pub(super) const fn encode(value: i16) -> u32 {
         let trunk = (value & i12::MASK) as u32;

--- a/src/instructions/simmi.rs
+++ b/src/instructions/simmi.rs
@@ -24,7 +24,7 @@ impl SImmI {
             + (((value & Self::L_MASK) as i32) >> Self::L_RSHIFT)) as i16
     }
 
-    /// Encdoe the 12-bit immediate value into an `S`-type instruction.
+    /// Encode the 12-bit immediate value into an `S`-type instruction.
     #[inline]
     pub(super) const fn encode(value: i16) -> u32 {
         let trunk = (value & i12::MASK) as u32;

--- a/src/instructions/types.rs
+++ b/src/instructions/types.rs
@@ -1,3 +1,15 @@
+//! RISC-V defines a number of different instruction types outlined below.
+//!
+//! | Type | Description                      |
+//! | ---- | -------------------------------- |
+//! | R    | Register type instruction        |
+//! | I    | Immediate type instruction       |
+//! | U    | Upper Immediate type instruction |
+//! | S    | Store type instruction           |
+//! | B    | Branch type instruction          |
+//! | J    | Jump type instruction            |
+//!
+//! This module includes helpers for encoding instructions of the different types.
 use crate::registers::Register;
 
 use super::{
@@ -5,45 +17,61 @@ use super::{
     simmi::SImmI,
 };
 
+/// `R`-type instructions - Register type instructions.
 pub(super) struct R;
 
 impl R {
+    /// Encode the source and destination registers as an `R`-type instruction.
     pub(super) const fn encode(rd: Register, rs1: Register, rs2: Register) -> u32 {
         Rd::encode(rd) + Rs1::encode(rs1) + Rs2::encode(rs2)
     }
 }
 
+/// `I`-type instructions - Immediate type instructions.
 pub(super) struct I;
 
 impl I {
+    /// Encode the source and destination registers, and immediate value as an
+    /// `I`-type instruction.
     pub(super) const fn encode(rd: Register, rs1: Register, imm: i16) -> u32 {
         Rd::encode(rd) + Rs1::encode(rs1) + ImmI::encode(imm)
     }
 
+    /// Encode the source and destination registers, and `CSR` value as an
+    /// `I`-type instruction.
     pub(super) const fn encode_csr(rd: Register, rs1: Register, csr: u16) -> u32 {
         Rd::encode(rd) + Rs1::encode(rs1) + Csr::encode(csr)
     }
 
+    /// Encode the destination register, immediate value, and `CSR` value as an
+    /// `I`-type instruction.
     pub(super) const fn encode_csri(rd: Register, imm: u8, csr: u16) -> u32 {
         Rd::encode(rd) + CsrImm::encode(imm) + Csr::encode(csr)
     }
 
+    /// Encode the source and destination registers, and shift amount as an
+    /// `I`-type instruction.
     pub(super) const fn encode_shamt(rd: Register, rs1: Register, shamt: u8) -> u32 {
         Rd::encode(rd) + Rs1::encode(rs1) + Shamt::encode(shamt)
     }
 }
 
+/// `U`-type instructions - Upper immediate type instructions.
 pub(super) struct U;
 
 impl U {
+    /// Encode the destination register and immediate value as an `U`-type
+    /// instruction.
     pub(super) const fn encode(rd: Register, imm: i32) -> u32 {
         Rd::encode(rd) + ImmU::encode(imm)
     }
 }
 
+/// `S`-type instructions - Store type instructions.
 pub(super) struct S;
 
 impl S {
+    /// Encode the source registers and immediate value as an `S`-type instruction.
     pub(super) const fn encode(rs1: Register, rs2: Register, simmi: i16) -> u32 {
         Rs1::encode(rs1) + Rs2::encode(rs2) + SImmI::encode(simmi)
     }

--- a/src/integer.rs
+++ b/src/integer.rs
@@ -1,21 +1,103 @@
+//! Traits and constants for handling integer conversion for
+//! [crate::registers::Register] types.
+
+/// The 12-bit signed integer type.
 pub(crate) mod i12 {
+    /// The largest value that can be represented by this integer type
+    /// (2<sup>11</sup> &minus; 1).
     pub const MAX: i16 = 2047;
+    /// The smallest value that can be represented by this integer type
+    /// (&minus;2<sup>11</sup>).
     pub const MIN: i16 = -2048;
+    /// The mask to extract an `i12` from a 16-bit integer type.
     pub const MASK: i16 = 0b_0000_1111_1111_1111;
+
+    /// Extracts the `i12` value from the [i32] then sign-extends it to an `i16`.
+    pub fn sign_extend(value: i32) -> i16 {
+        if is_positive(value) {
+            (value & 0x7FF) as i16
+        } else {
+            (value & 0xFFF | 0xF000) as i16
+        }
+    }
+
+    /// Returns `true` if the provided [i32] represents a positive `i12` value.
+    pub fn is_positive(value: i32) -> bool {
+        value & 0b_1000_0000_0000 == 0
+    }
 }
 
+/// Conversion from a signed to an unsigned type.
 pub(crate) trait AsUnsigned<N> {
+    /// Convert this to its associated unsigned type.
+    ///
+    /// Note this is a call to simply reinterpret the bytes as an unsigned type.
+    /// This is not a value preserving operation.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// let signed = -1_i8;
+    /// assert_eq!(signed.as_unsigned(), u8::MAX);
+    /// let unsigned = u8::MAX;
+    /// assert_eq!(unsigned.as_unsigned(), u8::MAX);
+    /// ```
     fn as_unsigned(&self) -> N;
 }
 
+/// Conversion from a unsigned to an signed type.
 pub(crate) trait AsSigned<N> {
+    /// Convert this to its associated signed type.
+    ///
+    /// Note this is a call to simply reinterpret the bytes as a signed type.
+    /// This is not a value preserving operation.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// let unsigned = u16::MAX;
+    /// assert_eq!(unsigned.as_signed(), -1_i16);
+    /// let signed = i16::MAX;
+    /// assert_eq!(signed.as_signed(), i16::MAX);
+    /// ```
     fn as_signed(&self) -> N;
 }
 
+/// Conversion to a [usize].
 pub trait AsUsize {
+    /// Convert this to a [usize].
+    ///
+    /// Note this is a call to simply reinterpret the bytes as an unsigned type.
+    /// This is not a value preserving operation.
+    ///
+    /// # Example
+    ///
+    /// On a 64-bit (or narrower pointer width) system:
+    ///
+    /// ```ignore
+    /// let signed: i64 = -1;
+    /// assert_eq!(signed.as_usize(), usize::MAX);
+    /// let unsigned = u64::MAX;
+    /// assert_eq!(unsigned.as_usize(), usize::MAX);
+    /// ```
     fn as_usize(&self) -> usize;
 }
 
+/// Implements [AsUnsigned], [AsUnsigned], and [AsUsize] for the provided
+/// signed and unsigned types.
+///
+/// # Example
+///
+/// The following will implement the above mentioned traits for the built in
+/// integer types
+///
+/// ```ignore
+/// impl_signed_unsigned!(i8, u8);
+/// impl_signed_unsigned!(i16, u16);
+/// impl_signed_unsigned!(i32, u32);
+/// impl_signed_unsigned!(i64, u64);
+/// impl_signed_unsigned!(i128, u128);
+/// ```
 macro_rules! impl_signed_unsigned {
     ($signed:ty, $unsigned:ty) => {
         impl AsUnsigned<$unsigned> for $signed {
@@ -56,3 +138,68 @@ impl_signed_unsigned!(i16, u16);
 impl_signed_unsigned!(i32, u32);
 impl_signed_unsigned!(i64, u64);
 impl_signed_unsigned!(i128, u128);
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn as_unsigned() {
+        assert_eq!((-1_i8).as_unsigned(), u8::MAX);
+        assert_eq!(u8::MAX.as_unsigned(), u8::MAX);
+        assert_eq!((-1_i16).as_unsigned(), u16::MAX);
+        assert_eq!(u16::MAX.as_unsigned(), u16::MAX);
+        assert_eq!((-1_i32).as_unsigned(), u32::MAX);
+        assert_eq!(u32::MAX.as_unsigned(), u32::MAX);
+        assert_eq!((-1_i64).as_unsigned(), u64::MAX);
+        assert_eq!(u64::MAX.as_unsigned(), u64::MAX);
+        assert_eq!((-1_i128).as_unsigned(), u128::MAX);
+        assert_eq!(u128::MAX.as_unsigned(), u128::MAX);
+    }
+
+    #[test]
+    fn as_signed() {
+        assert_eq!(i8::MAX.as_signed(), i8::MAX);
+        assert_eq!(u8::MAX.as_signed(), -1);
+        assert_eq!(i16::MAX.as_signed(), i16::MAX);
+        assert_eq!(u16::MAX.as_signed(), -1);
+        assert_eq!(i32::MAX.as_signed(), i32::MAX);
+        assert_eq!(u32::MAX.as_signed(), -1);
+        assert_eq!(i64::MAX.as_signed(), i64::MAX);
+        assert_eq!(u64::MAX.as_signed(), -1);
+        assert_eq!(i128::MAX.as_signed(), i128::MAX);
+        assert_eq!(u128::MAX.as_signed(), -1);
+    }
+
+    #[test]
+    #[cfg(target_pointer_width = "32")]
+    fn as_usize() {
+        assert_eq!((-1_i32).as_usize(), usize::MAX);
+        assert_eq!(u32::MAX.as_usize(), usize::MAX);
+    }
+
+    #[test]
+    #[cfg(target_pointer_width = "64")]
+    fn as_usize() {
+        assert_eq!((-1_i64).as_usize(), usize::MAX);
+        assert_eq!(u64::MAX.as_usize(), usize::MAX);
+    }
+
+    #[test]
+    fn sign_extend_i12_test() {
+        let neg_1 = 0b_1111_1111_1111 as i32;
+        let max_i12 = 0b_0111_1111_1111 as i32;
+        let min_i12 = 0b_1000_0000_0000 as i32;
+        assert_eq!(i12::sign_extend(neg_1), -1);
+        assert_eq!(i12::sign_extend(max_i12), i12::MAX);
+        assert_eq!(i12::sign_extend(min_i12), i12::MIN);
+    }
+
+    #[test]
+    fn is_positive_i12_test() {
+        let neg_1 = 0b_1111_1111_1111 as i32;
+        let max_i12 = 0b_0111_1111_1111 as i32;
+        assert!(!i12::is_positive(neg_1));
+        assert!(i12::is_positive(max_i12));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,8 @@
-mod csr;
+//! RISKV - An implementation of a RISC-V emulator
+#![warn(unused_crate_dependencies)]
+#![deny(missing_docs, clippy::missing_docs_in_private_items)]
+
+pub mod csr;
 pub mod instruction_set;
 mod instructions;
 mod integer;

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -1,12 +1,18 @@
+//! The computer's memory.
 use crate::integer::AsSigned;
 
+/// An expandable implementation of the computer's memory.
+///
+/// The bytes of memory are stored as little endian.
+///
+// TODO: consider making memory a trait so we can support different endianess
+// and fixed size.
 #[derive(Debug, Default, PartialEq, Eq, Clone)]
 pub struct Memory {
+    /// The raw bytes of the memory
     data: Vec<u8>,
 }
 
-// Note this implementation of memory is little endian. It would be nice to make memory generic
-// over endianess.
 impl Memory {
     /// Get 8 bits of memory
     pub fn load_byte(&mut self, location: usize) -> i8 {
@@ -44,6 +50,11 @@ impl Memory {
         self.data[location..location + 4].copy_from_slice(&value.to_le_bytes());
     }
 
+    /// Resize this memory
+    ///
+    /// If `location + N` is greater than `len`, the `Memory` is extended by the
+    /// difference, with each additional slot filled with `value`.
+    /// If `location` is less than `len`, this method does nothing.
     #[inline]
     pub(super) fn resize<const N: usize>(&mut self, location: usize) {
         if location + N > self.data.len() {
@@ -51,6 +62,12 @@ impl Memory {
         }
     }
 
+    /// Given the initial state of memory the contents of this memory will get
+    /// applied on top of the initial state.
+    ///
+    /// This is useful for tests where what we really care about is the memory
+    /// `diff` rather than the whole state of the memory including all the
+    /// programmes instructions.
     #[cfg(test)]
     pub(crate) fn with_initial_state(&mut self, Self { mut data }: Self) {
         std::mem::swap(&mut self.data, &mut data);

--- a/src/registers.rs
+++ b/src/registers.rs
@@ -1,9 +1,13 @@
+//! The processors registers.
+//!
+//! A RISC-V processor has 32 integer registers, referred to either as `x0-x31`
+//! or by their ABI name.
 use std::{
     fmt::Debug,
     ops::{Deref, DerefMut},
 };
 
-/// Struct representing the RISK-V Processor.
+/// Struct representing the RISK-V processor registers.
 ///
 /// The processor contains the following registers.
 ///
@@ -43,37 +47,228 @@ use std::{
 /// | 31 | -   | x31      | t6       | temporary register 6                 | caller   |
 #[derive(Default, PartialEq, Eq)]
 pub(super) struct Registers<T> {
+    /// The zero register.
+    ///
+    /// This register will always yield zero. Setting the destination register
+    /// of a specific instruction will discard the result.
+    ///
+    /// In particular instructions that usually trigger read read side effects
+    /// should not be triggered if their destination register is the zero register.
+    ///
+    /// Also referred to as `x0`.
     pub(super) zero: ZeroRegister<T>,
+
+    /// Return address register.
+    ///
+    /// Usually the value will be set by the caller.
+    ///
+    /// Also referred to as `x1`.
     pub(super) ra: T,
+
+    /// Stack pointer register
+    ///
+    /// Usually the value will be set by the callee.
+    ///
+    /// Also referred to as `x2`.
     pub(super) sp: T,
+
+    /// Global pointer register
+    ///
+    /// Also referred to as `x2`.
     pub(super) gp: T,
+
+    /// Thread pointer register
+    ///
+    /// Also referred to as `x2`.
     pub(super) tp: T,
+
+    /// Temporary register 0.
+    ///
+    /// Usually the value will be set by the caller.
+    ///
+    /// Also referred to as `x5`.
     pub(super) t0: T,
+
+    /// Temporary register 1.
+    ///
+    /// Usually the value will be set by the caller.
+    ///
+    /// Also referred to as `x6`.
     pub(super) t1: T,
+
+    /// Temporary register 2.
+    ///
+    /// Usually the value will be set by the caller.
+    ///
+    /// Also referred to as `x7`.
     pub(super) t2: T,
+
+    /// Saved register 0.
+    ///
+    /// Usually the value will be set by the callee.
+    ///
+    /// Also referred to as `x8`.
     pub(super) s0: T,
+
+    /// Saved register 1.
+    ///
+    /// Usually the value will be set by the callee.
+    ///
+    /// Also referred to as `x9`.
     pub(super) s1: T,
+
+    /// Function argument register 0.
+    ///
+    /// Usually the value will be set by the caller.
+    ///
+    /// Also referred to as `x10`.
     pub(super) a0: T,
+
+    /// Function argument register 1.
+    ///
+    /// Usually the value will be set by the caller.
+    ///
+    /// Also referred to as `x11`.
     pub(super) a1: T,
+
+    /// Function argument register 2.
+    ///
+    /// Usually the value will be set by the caller.
+    ///
+    /// Also referred to as `x12`.
     pub(super) a2: T,
+
+    /// Function argument register 3.
+    ///
+    /// Usually the value will be set by the caller.
+    ///
+    /// Also referred to as `x13`.
     pub(super) a3: T,
+
+    /// Function argument register 4.
+    ///
+    /// Usually the value will be set by the caller.
+    ///
+    /// Also referred to as `x14`.
     pub(super) a4: T,
+
+    /// Function argument register 5.
+    ///
+    /// Usually the value will be set by the caller.
+    ///
+    /// Also referred to as `x15`.
     pub(super) a5: T,
+
+    /// Function argument register 6.
+    ///
+    /// Usually the value will be set by the caller.
+    ///
+    /// Also referred to as `x16`.
     pub(super) a6: T,
+
+    /// Function argument register 7.
+    ///
+    /// Usually the value will be set by the caller.
+    ///
+    /// Also referred to as `x17`.
     pub(super) a7: T,
+
+    /// Saved register 2.
+    ///
+    /// Usually the value will be set by the callee.
+    ///
+    /// Also referred to as `x18`.
     pub(super) s2: T,
+
+    /// Saved register 3.
+    ///
+    /// Usually the value will be set by the callee.
+    ///
+    /// Also referred to as `x19`.
     pub(super) s3: T,
+
+    /// Saved register 4.
+    ///
+    /// Usually the value will be set by the callee.
+    ///
+    /// Also referred to as `x20`.
     pub(super) s4: T,
+
+    /// Saved register 5.
+    ///
+    /// Usually the value will be set by the callee.
+    ///
+    /// Also referred to as `x21`.
     pub(super) s5: T,
+
+    /// Saved register 6.
+    ///
+    /// Usually the value will be set by the callee.
+    ///
+    /// Also referred to as `x22`.
     pub(super) s6: T,
+
+    /// Saved register 7.
+    ///
+    /// Usually the value will be set by the callee.
+    ///
+    /// Also referred to as `x23`.
     pub(super) s7: T,
+
+    /// Saved register 8.
+    ///
+    /// Usually the value will be set by the callee.
+    ///
+    /// Also referred to as `x24`.
     pub(super) s8: T,
+
+    /// Saved register 9.
+    ///
+    /// Usually the value will be set by the callee.
+    ///
+    /// Also referred to as `x25`.
     pub(super) s9: T,
+
+    /// Saved register 10.
+    ///
+    /// Usually the value will be set by the callee.
+    ///
+    /// Also referred to as `x26`.
     pub(super) s10: T,
+
+    /// Saved register 11.
+    ///
+    /// Usually the value will be set by the callee.
+    ///
+    /// Also referred to as `x27`.
     pub(super) s11: T,
+
+    /// Temporary register 3.
+    ///
+    /// Usually the value will be set by the caller.
+    ///
+    /// Also referred to as `x28`.
     pub(super) t3: T,
+
+    /// Temporary register 4.
+    ///
+    /// Usually the value will be set by the caller.
+    ///
+    /// Also referred to as `x29`.
     pub(super) t4: T,
+
+    /// Temporary register 5.
+    ///
+    /// Usually the value will be set by the caller.
+    ///
+    /// Also referred to as `x30`.
     pub(super) t5: T,
+
+    /// Temporary register 6.
+    ///
+    /// Usually the value will be set by the caller.
+    ///
+    /// Also referred to as `x31`.
     pub(super) t6: T,
 }
 
@@ -93,11 +288,20 @@ where
     }
 }
 
+/// A struct encapsulated the behaviour of the zero register:
+/// - always yields zero when read
+/// - can be assigned to but this effectively discards the value
 #[derive(Default)]
 pub(super) struct ZeroRegister<T> {
+    /// This value will always be set to zero. Shared references are given to
+    /// this value.
     zero: T,
-    // Since zero is hard wired, we don't want to give out a mutable reference,
-    // this is a compromise until I think of a better way to do this.
+    /// Since the zero register is hard wired to zero and should always yeild
+    /// zero when read, we don't want to give out a mutable reference to it.
+    /// Therefore we give out a mutable reference to `_zero`, and each time we
+    /// ask for a mutable reference we reset this value to zero.
+    ///
+    /// Note: I'm not sure if there is a better way to do this currently.
     _zero: T,
 }
 
@@ -133,77 +337,247 @@ where
     }
 }
 
+/// A single processor register.
 #[repr(u8)]
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[allow(clippy::upper_case_acronyms)]
 pub(super) enum Register {
-    /// hardwired zero
+    /// The zero register.
+    ///
+    /// This register will always yield zero. Setting the destination register
+    /// of a specific instruction will discard the result.
+    ///
+    /// In particular instructions that usually trigger read read side effects
+    /// should not be triggered if their destination register is the zero register.
+    ///
+    /// Also referred to as `x0`.
     ZERO = 0,
-    /// return address
+
+    /// Return address register.
+    ///
+    /// Usually the value will be set by the caller.
+    ///
+    /// Also referred to as `x1`.
     RA = 1,
-    /// stack pointer
+
+    /// Stack pointer register
+    ///
+    /// Usually the value will be set by the callee.
+    ///
+    /// Also referred to as `x2`.
     SP = 2,
-    /// global pointer
+
+    /// Global pointer register
+    ///
+    /// Also referred to as `x2`.
     GP = 3,
-    /// thread pointer
+
+    /// Thread pointer register
+    ///
+    /// Also referred to as `x2`.
     TP = 4,
-    /// temporary register 0
+
+    /// Temporary register 0.
+    ///
+    /// Usually the value will be set by the caller.
+    ///
+    /// Also referred to as `x5`.
     T0 = 5,
-    /// temporary register 1
+
+    /// Temporary register 1.
+    ///
+    /// Usually the value will be set by the caller.
+    ///
+    /// Also referred to as `x6`.
     T1 = 6,
-    /// temporary register 2
+
+    /// Temporary register 2.
+    ///
+    /// Usually the value will be set by the caller.
+    ///
+    /// Also referred to as `x7`.
     T2 = 7,
-    /// saved register 0 / frame pointer
+
+    /// Saved register 0 / frame pointer.
+    ///
+    /// Usually the value will be set by the callee.
+    ///
+    /// Also referred to as `x8`.
     S0 = 8,
-    /// saved register 1
+
+    /// Saved register 1.
+    ///
+    /// Usually the value will be set by the callee.
+    ///
+    /// Also referred to as `x9`.
     S1 = 9,
-    /// function argument 0 / return value 0
+
+    /// Function argument register 0 / return value 0
+    ///
+    /// Usually the value will be set by the caller.
+    ///
+    /// Also referred to as `x10`.
     A0 = 10,
-    /// function argument 1 / return value 1
+
+    /// Function argument register 1 / return value 1.
+    ///
+    /// Usually the value will be set by the caller.
+    ///
+    /// Also referred to as `x11`.
     A1 = 11,
-    /// function argument 2
+
+    /// Function argument register 2.
+    ///
+    /// Usually the value will be set by the caller.
+    ///
+    /// Also referred to as `x12`.
     A2 = 12,
-    /// function argument 3
+
+    /// Function argument register 3.
+    ///
+    /// Usually the value will be set by the caller.
+    ///
+    /// Also referred to as `x13`.
     A3 = 13,
-    /// function argument 4
+
+    /// Function argument register 4.
+    ///
+    /// Usually the value will be set by the caller.
+    ///
+    /// Also referred to as `x14`.
     A4 = 14,
-    /// function argument 5
+
+    /// Function argument register 5.
+    ///
+    /// Usually the value will be set by the caller.
+    ///
+    /// Also referred to as `x15`.
     A5 = 15,
-    /// function argument 6
+
+    /// Function argument register 6.
+    ///
+    /// Usually the value will be set by the caller.
+    ///
+    /// Also referred to as `x16`.
     A6 = 16,
-    /// function argument 7
+
+    /// Function argument register 7.
+    ///
+    /// Usually the value will be set by the caller.
+    ///
+    /// Also referred to as `x17`.
     A7 = 17,
-    /// saved register 2
+
+    /// Saved register 2.
+    ///
+    /// Usually the value will be set by the callee.
+    ///
+    /// Also referred to as `x18`.
     S2 = 18,
-    /// saved register 3
+
+    /// Saved register 3.
+    ///
+    /// Usually the value will be set by the callee.
+    ///
+    /// Also referred to as `x19`.
     S3 = 19,
-    /// saved register 4
+
+    /// Saved register 4.
+    ///
+    /// Usually the value will be set by the callee.
+    ///
+    /// Also referred to as `x20`.
     S4 = 20,
-    /// saved register 5
+
+    /// Saved register 5.
+    ///
+    /// Usually the value will be set by the callee.
+    ///
+    /// Also referred to as `x21`.
     S5 = 21,
-    /// saved register 6
+
+    /// Saved register 6.
+    ///
+    /// Usually the value will be set by the callee.
+    ///
+    /// Also referred to as `x22`.
     S6 = 22,
-    /// saved register 7
+
+    /// Saved register 7.
+    ///
+    /// Usually the value will be set by the callee.
+    ///
+    /// Also referred to as `x23`.
     S7 = 23,
-    /// saved register 8
+
+    /// Saved register 8.
+    ///
+    /// Usually the value will be set by the callee.
+    ///
+    /// Also referred to as `x24`.
     S8 = 24,
-    /// saved register 9
+
+    /// Saved register 9.
+    ///
+    /// Usually the value will be set by the callee.
+    ///
+    /// Also referred to as `x25`.
     S9 = 25,
-    /// saved register 10
+
+    /// Saved register 10.
+    ///
+    /// Usually the value will be set by the callee.
+    ///
+    /// Also referred to as `x26`.
     S10 = 26,
-    /// saved register 11
+
+    /// Saved register 11.
+    ///
+    /// Usually the value will be set by the callee.
+    ///
+    /// Also referred to as `x27`.
     S11 = 27,
-    /// temporary register 3
+
+    /// Temporary register 3.
+    ///
+    /// Usually the value will be set by the caller.
+    ///
+    /// Also referred to as `x28`.
     T3 = 28,
-    /// temporary register 4
+
+    /// Temporary register 4.
+    ///
+    /// Usually the value will be set by the caller.
+    ///
+    /// Also referred to as `x29`.
     T4 = 29,
-    /// temporary register 5
+
+    /// Temporary register 5.
+    ///
+    /// Usually the value will be set by the caller.
+    ///
+    /// Also referred to as `x30`.
     T5 = 30,
-    /// temporary register 6
+
+    /// Temporary register 6.
+    ///
+    /// Usually the value will be set by the caller.
+    ///
+    /// Also referred to as `x31`.
     T6 = 31,
 }
 
 impl Register {
+    /// Converts the [u8] into a [Register].
+    ///
+    /// The [u8] will be masked to ensure it always returns a valid register.
+    ///
+    /// # Example
+    ///
+    /// ```ignored
+    /// assert_eq!(Register::const_from(0), Register::ZERO);
+    /// assert_eq!(Register::const_from(32), Register::ZERO);
+    /// ```
     pub(crate) const fn const_from(value: u8) -> Register {
         match value & 0b_0001_1111 {
             0 => Register::ZERO,

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,1 +1,2 @@
+//! Helpers for testing.
 pub(crate) mod macros;

--- a/src/test/macros.rs
+++ b/src/test/macros.rs
@@ -1,3 +1,4 @@
+//! Macros to help write clean and concise tests without lots of boiler plate.
 use crate::instructions::Instruction;
 
 /// Used by the test macros to make it possible to treat instructions and


### PR DESCRIPTION
This PR improve the documentation of the crate by

- adding documentation to all items in the crate.
- denying `missing_docs` and `clippy::missing_docs_in_private_items)` for the crate (to ensure consistent documentation moving forward)
- adds a GH workflow to publish the documentation (including all the private items) to GH pages.

## Commits:

- Add documentation to all items
- Add workflow to publish docs to github pages
