### PR TITLE
Add jump instructions

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,0 +1,51 @@
+name: Deploy Crate Documentation
+
+on:
+  push:
+    branches: ["master"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+env:
+  DOC_DIR: ./doc
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+      - name: Setup Pages
+        uses: actions/configure-pages@v2
+      - name: Build docs
+        run: |
+          cargo doc --document-private-items
+          rm -rf $DOC_DIR
+          echo "<meta http-equiv=\"refresh\" content=\"0; url=tiptop\">" > target/doc/index.html
+          cp -r target/doc $DOC_DIR
+      - name: Fix file permissions
+        # To fix file permissions issue: https://github.com/actions/deploy-pages/issues/188
+        run: chmod -c -R +rX $DOC_DIR
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          # Upload entire repository
+          path: ${{ env.DOC_DIR }}
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Feel free to contribute and get involved if you would like to learn more about a
   - [X] SB
   - [X] SH
   - [X] SW
-  - [ ] JAL
+  - [x] JAL
   - [ ] JALR
   - [ ] BEQ
   - [ ] BNE

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Feel free to contribute and get involved if you would like to learn more about a
   - [X] SH
   - [X] SW
   - [x] JAL
-  - [ ] JALR
+  - [x] JALR
   - [ ] BEQ
   - [ ] BNE
   - [ ] BLT

--- a/src/instruction_set.rs
+++ b/src/instruction_set.rs
@@ -18,10 +18,17 @@ use crate::{csr::ControlStatusRegisters, processor::Processor};
 ///
 /// Different instructions can raise exceptions in the processor for system
 /// interrupt.
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum Exception {
     /// The processor exception raised when an instruction is not recognised.
     UnimplementedInstruction(u32),
+
+    /// Misaligned Instruction Fetch exception.
+    ///
+    /// _Note_: Instruction fetch misaligned exceptions are not possible on
+    /// machines that support extensions with `16`-bit aligned instructions,
+    /// such as the compressed instruction set extension, C.
+    MisalignedInstructionFetch,
 }
 
 impl Display for Exception {
@@ -31,6 +38,9 @@ impl Display for Exception {
                 "The given instruction is not yet implemented {:#034b}",
                 instuction.to_le()
             )),
+            Self::MisalignedInstructionFetch => {
+                f.write_str("Attempted to fetch an instruction not aligned to a 32-bit boundary")
+            }
         }
     }
 }

--- a/src/instructions/impl_instruction_set.rs
+++ b/src/instructions/impl_instruction_set.rs
@@ -1262,4 +1262,19 @@ mod test {
             throws: Exception::MisalignedInstructionFetch,
         );
     }
+
+    #[test]
+    fn execute_call() {
+        test_execute!(
+            Instruction::CALL(50_000_000),
+            executed_on: {registers: {}, pc: 1000},
+            results_in: {registers: {ra: 1008}, pc: 50_001_000 },
+        );
+        test_execute!(
+            Instruction::CALL(50_000_003),
+            executed_on: {registers: {}, pc: 84},
+            throws: Exception::MisalignedInstructionFetch,
+            with_final_state: {registers: {ra: 49999956}, pc: 88},
+        );
+    }
 }

--- a/src/instructions/impl_instruction_set.rs
+++ b/src/instructions/impl_instruction_set.rs
@@ -1220,4 +1220,18 @@ mod test {
             throws: Exception::MisalignedInstructionFetch,
         );
     }
+
+    #[test]
+    fn execute_jalr_psuedoinstruction() {
+        test_execute!(
+            Instruction::JALR(Register::A0),
+            executed_on: {registers: {a0: 5000}, pc: 1000},
+            results_in: {registers: {ra: 1004, a0: 5000}, pc: 5000 },
+        );
+        test_execute!(
+            Instruction::JALR(Register::S3),
+            executed_on: {registers: {s3: 42}, pc: 84},
+            throws: Exception::MisalignedInstructionFetch,
+        );
+    }
 }

--- a/src/instructions/impl_instruction_set.rs
+++ b/src/instructions/impl_instruction_set.rs
@@ -1277,4 +1277,19 @@ mod test {
             with_final_state: {registers: {ra: 49999956}, pc: 88},
         );
     }
+
+    #[test]
+    fn execute_tail() {
+        test_execute!(
+            Instruction::TAIL(50_000_000),
+            executed_on: {registers: {}, pc: 1000},
+            results_in: {registers: {t1: 50_000_872}, pc: 50_001_000 },
+        );
+        test_execute!(
+            Instruction::TAIL(50_000_003),
+            executed_on: {registers: {}, pc: 84},
+            throws: Exception::MisalignedInstructionFetch,
+            with_final_state: {registers: {t1: 49999956}, pc: 88},
+        );
+    }
 }

--- a/src/instructions/impl_instruction_set.rs
+++ b/src/instructions/impl_instruction_set.rs
@@ -1248,4 +1248,18 @@ mod test {
             throws: Exception::MisalignedInstructionFetch,
         );
     }
+
+    #[test]
+    fn execute_ret() {
+        test_execute!(
+            Instruction::RET,
+            executed_on: {registers: {ra: 5000}, pc: 1000},
+            results_in: {registers: {ra: 5000}, pc: 5000 },
+        );
+        test_execute!(
+            Instruction::RET,
+            executed_on: {registers: {ra: 42}, pc: 84},
+            throws: Exception::MisalignedInstructionFetch,
+        );
+    }
 }

--- a/src/instructions/impl_instruction_set.rs
+++ b/src/instructions/impl_instruction_set.rs
@@ -1234,4 +1234,18 @@ mod test {
             throws: Exception::MisalignedInstructionFetch,
         );
     }
+
+    #[test]
+    fn execute_jr() {
+        test_execute!(
+            Instruction::JR(Register::A0),
+            executed_on: {registers: {a0: 5000}, pc: 1000},
+            results_in: {registers: {a0: 5000}, pc: 5000 },
+        );
+        test_execute!(
+            Instruction::JR(Register::S3),
+            executed_on: {registers: {s3: 42}, pc: 84},
+            throws: Exception::MisalignedInstructionFetch,
+        );
+    }
 }

--- a/src/instructions/impl_instruction_set.rs
+++ b/src/instructions/impl_instruction_set.rs
@@ -1126,4 +1126,42 @@ mod test {
             to: {registers: {t0: 40004}, pc: 25000 },
         );
     }
+
+    #[test]
+    fn execute_jal_pseudoinstruction() {
+        test_execute!(
+            Instruction::JAL(84),
+            changes: {registers: {}},
+            to: {registers: {ra: 4}, pc: 84},
+        );
+        test_execute!(
+            Instruction::JAL(1000),
+            changes: {registers: {}, pc: 5000},
+            to: {registers: {ra: 5004}, pc: 6000 },
+        );
+        test_execute!(
+            Instruction::JAL(-42),
+            changes: {registers: {}, pc: 84},
+            to: {registers: {ra: 88}, pc: 42 },
+        );
+    }
+
+    #[test]
+    fn execute_j() {
+        test_execute!(
+            Instruction::J(84),
+            changes: {registers: {}},
+            to: {registers: {}, pc: 84},
+        );
+        test_execute!(
+            Instruction::J(1000),
+            changes: {registers: {}, pc: 5000},
+            to: {registers: {}, pc: 6000 },
+        );
+        test_execute!(
+            Instruction::J(-42),
+            changes: {registers: {}, pc: 84},
+            to: {registers: {}, pc: 42 },
+        );
+    }
 }

--- a/src/instructions/impl_instruction_set.rs
+++ b/src/instructions/impl_instruction_set.rs
@@ -229,8 +229,8 @@ mod test {
         ] {
             test_execute!(
                 Instruction::LI(Register::T1, i),
-                changes: {registers: {}},
-                to: {registers: {t1: i}, pc: pc_inc},
+                executed_on: {registers: {}},
+                results_in: {registers: {t1: i}, pc: pc_inc},
             );
         }
     }
@@ -239,18 +239,18 @@ mod test {
     fn execute_not() {
         test_execute!(
             Instruction::NOT(Register::A5, Register::A6),
-            changes: {registers: {a6: -1}},
-            to: {registers: {a5: 0, a6: -1}, pc: 4},
+            executed_on: {registers: {a6: -1}},
+            results_in: {registers: {a5: 0, a6: -1}, pc: 4},
         );
         test_execute!(
             Instruction::NOT(Register::A5, Register::A6),
-            changes: {registers: {a6: 0}},
-            to: {registers: {a5: -1, a6: 0}, pc: 4},
+            executed_on: {registers: {a6: 0}},
+            results_in: {registers: {a5: -1, a6: 0}, pc: 4},
         );
         test_execute!(
             Instruction::NOT(Register::A5, Register::A6),
-            changes: {registers: {a6: 42}},
-            to: {registers: {a5: -43, a6: 42}, pc: 4},
+            executed_on: {registers: {a6: 42}},
+            results_in: {registers: {a5: -43, a6: 42}, pc: 4},
         );
     }
 
@@ -258,23 +258,23 @@ mod test {
     fn execute_neg() {
         test_execute!(
             Instruction::NEG(Register::S5, Register::S6),
-            changes: {registers: {s6: -1}},
-            to: {registers: {s5: 1, s6: -1}, pc: 4},
+            executed_on: {registers: {s6: -1}},
+            results_in: {registers: {s5: 1, s6: -1}, pc: 4},
         );
         test_execute!(
             Instruction::NEG(Register::S5, Register::S6),
-            changes: {registers: {s6: -1}},
-            to: {registers: {s5: 1, s6: -1}, pc: 4},
+            executed_on: {registers: {s6: -1}},
+            results_in: {registers: {s5: 1, s6: -1}, pc: 4},
         );
         test_execute!(
             Instruction::NEG(Register::S5, Register::S6),
-            changes: {registers: {s6: 42}},
-            to: {registers: {s5: -42, s6: 42}, pc: 4},
+            executed_on: {registers: {s6: 42}},
+            results_in: {registers: {s5: -42, s6: 42}, pc: 4},
         );
         test_execute!(
             Instruction::NEG(Register::S5, Register::S6),
-            changes: {registers: {s6: 0}},
-            to: {registers: {s5: 0, s6: 0}, pc: 4},
+            executed_on: {registers: {s6: 0}},
+            results_in: {registers: {s5: 0, s6: 0}, pc: 4},
         );
     }
 
@@ -282,8 +282,8 @@ mod test {
     fn execute_mov() {
         test_execute!(
             Instruction::MOV(Register::T5, Register::T6),
-            changes: {registers: {t6: -1}},
-            to: {registers: {t5: -1, t6: -1}, pc: 4},
+            executed_on: {registers: {t6: -1}},
+            results_in: {registers: {t5: -1, t6: -1}, pc: 4},
         );
     }
 
@@ -291,18 +291,18 @@ mod test {
     fn execute_seqz() {
         test_execute!(
             Instruction::SEQZ(Register::A3, Register::A1),
-            changes: {registers: {a1: -1}},
-            to: {registers: {a1: -1, a3: 0}, pc: 4},
+            executed_on: {registers: {a1: -1}},
+            results_in: {registers: {a1: -1, a3: 0}, pc: 4},
         );
         test_execute!(
             Instruction::SEQZ(Register::A3, Register::A1),
-            changes: {registers: {a1: 0}},
-            to: {registers: {a1: 0, a3: 1}, pc: 4},
+            executed_on: {registers: {a1: 0}},
+            results_in: {registers: {a1: 0, a3: 1}, pc: 4},
         );
         test_execute!(
             Instruction::SEQZ(Register::A3, Register::A1),
-            changes: {registers: {a1: 1}},
-            to: {registers: {a1: 1, a3: 0}, pc: 4},
+            executed_on: {registers: {a1: 1}},
+            results_in: {registers: {a1: 1, a3: 0}, pc: 4},
         );
     }
 
@@ -310,18 +310,18 @@ mod test {
     fn execute_snez() {
         test_execute!(
             Instruction::SNEZ(Register::A3, Register::A1),
-            changes: {registers: {a1: -1}},
-            to: {registers: {a1: -1, a3: 1}, pc: 4},
+            executed_on: {registers: {a1: -1}},
+            results_in: {registers: {a1: -1, a3: 1}, pc: 4},
         );
         test_execute!(
             Instruction::SNEZ(Register::A3, Register::A1),
-            changes: {registers: {a1: 0}},
-            to: {registers: {a1: 0, a3: 0}, pc: 4},
+            executed_on: {registers: {a1: 0}},
+            results_in: {registers: {a1: 0, a3: 0}, pc: 4},
         );
         test_execute!(
             Instruction::SNEZ(Register::A3, Register::A1),
-            changes: {registers: {a1: 1}},
-            to: {registers: {a1: 1, a3: 1}, pc: 4},
+            executed_on: {registers: {a1: 1}},
+            results_in: {registers: {a1: 1, a3: 1}, pc: 4},
         );
     }
 
@@ -329,18 +329,18 @@ mod test {
     fn execute_sltz() {
         test_execute!(
             Instruction::SLTZ(Register::A3, Register::A1),
-            changes: {registers: {a1: -1}},
-            to: {registers: {a1: -1, a3: 1}, pc: 4},
+            executed_on: {registers: {a1: -1}},
+            results_in: {registers: {a1: -1, a3: 1}, pc: 4},
         );
         test_execute!(
             Instruction::SLTZ(Register::A3, Register::A1),
-            changes: {registers: {a1: 0}},
-            to: {registers: {a1: 0, a3: 0}, pc: 4},
+            executed_on: {registers: {a1: 0}},
+            results_in: {registers: {a1: 0, a3: 0}, pc: 4},
         );
         test_execute!(
             Instruction::SLTZ(Register::A3, Register::A1),
-            changes: {registers: {a1: 1}},
-            to: {registers: {a1: 1, a3: 0}, pc: 4},
+            executed_on: {registers: {a1: 1}},
+            results_in: {registers: {a1: 1, a3: 0}, pc: 4},
         );
     }
 
@@ -348,18 +348,18 @@ mod test {
     fn execute_sgtz() {
         test_execute!(
             Instruction::SGLZ(Register::A3, Register::A1),
-            changes: {registers: {a1: -1}},
-            to: {registers: {a1: -1, a3: 0}, pc: 4},
+            executed_on: {registers: {a1: -1}},
+            results_in: {registers: {a1: -1, a3: 0}, pc: 4},
         );
         test_execute!(
             Instruction::SGLZ(Register::A3, Register::A1),
-            changes: {registers: {a1: 0}},
-            to: {registers: {a1: 0, a3: 0}, pc: 4},
+            executed_on: {registers: {a1: 0}},
+            results_in: {registers: {a1: 0, a3: 0}, pc: 4},
         );
         test_execute!(
             Instruction::SGLZ(Register::A3, Register::A1),
-            changes: {registers: {a1: 1}},
-            to: {registers: {a1: 1, a3: 1}, pc: 4},
+            executed_on: {registers: {a1: 1}},
+            results_in: {registers: {a1: 1, a3: 1}, pc: 4},
         );
     }
 
@@ -367,8 +367,8 @@ mod test {
     fn execute_nop() {
         test_execute!(
             Instruction::NOP,
-            changes: {registers: {}},
-            to: {registers: {}, pc: 4},
+            executed_on: {registers: {}},
+            results_in: {registers: {}, pc: 4},
         );
     }
 
@@ -376,13 +376,13 @@ mod test {
     fn execute_lui() {
         test_execute!(
             Instruction::LUI { rd: Register::S11, imm: 0x2BAAA },
-            changes: {registers: {}},
-            to: {registers: {s11: 0x2BAA_A000}, pc: 4},
+            executed_on: {registers: {}},
+            results_in: {registers: {s11: 0x2BAA_A000}, pc: 4},
         );
         test_execute!(
             Instruction::LUI { rd: Register::S11, imm: 0xDEAD_B },
-            changes: {registers: {}},
-            to: {registers: {s11: i32::from_be_bytes([0xDE, 0xAD, 0xB0, 0x00])}, pc: 4},
+            executed_on: {registers: {}},
+            results_in: {registers: {s11: i32::from_be_bytes([0xDE, 0xAD, 0xB0, 0x00])}, pc: 4},
         );
     }
 
@@ -390,13 +390,13 @@ mod test {
     fn execute_auipc() {
         test_execute!(
             Instruction::AUIPC { rd: Register::SP, imm: 0x2BAAA },
-            changes: {registers: {}, pc: 0x0000_0AAD},
-            to: {registers: {sp: 0x2BAA_AAAD}, pc: 0x0000_0AB1},
+            executed_on: {registers: {}, pc: 0x0000_0AAD},
+            results_in: {registers: {sp: 0x2BAA_AAAD}, pc: 0x0000_0AB1},
         );
         test_execute!(
             Instruction::AUIPC { rd: Register::SP, imm: 0xDEAD_B },
-            changes: {registers: {}, pc: 0x0000_0EAF},
-            to: {registers: {sp: i32::from_be_bytes([0xDE, 0xAD, 0xBE, 0xAF])}, pc: 0x0000_0EB3},
+            executed_on: {registers: {}, pc: 0x0000_0EAF},
+            results_in: {registers: {sp: i32::from_be_bytes([0xDE, 0xAD, 0xBE, 0xAF])}, pc: 0x0000_0EB3},
         );
     }
 
@@ -404,8 +404,8 @@ mod test {
     fn execute_addi() {
         test_execute!(
             Instruction::ADDI{rd: Register::T4, rs1: Register::T1, imm: 42},
-            changes: {registers: {t1: 42}},
-            to: {registers: {t1: 42, t4: 84}, pc: 4},
+            executed_on: {registers: {t1: 42}},
+            results_in: {registers: {t1: 42, t4: 84}, pc: 4},
         );
     }
 
@@ -413,18 +413,18 @@ mod test {
     fn execute_slti() {
         test_execute!(
             Instruction::SLTI{rd: Register::T4, rs1: Register::T1, imm: 43},
-            changes: {registers: {t1: 42}},
-            to: {registers: {t1: 42, t4: 1}, pc: 4},
+            executed_on: {registers: {t1: 42}},
+            results_in: {registers: {t1: 42, t4: 1}, pc: 4},
         );
         test_execute!(
             Instruction::SLTI{rd: Register::T4, rs1: Register::T1, imm: 42},
-            changes: {registers: {t1: 42, t4: 100}},
-            to: {registers: {t1: 42, t4: 0}, pc: 4},
+            executed_on: {registers: {t1: 42, t4: 100}},
+            results_in: {registers: {t1: 42, t4: 0}, pc: 4},
         );
         test_execute!(
             Instruction::SLTI{rd: Register::T4, rs1: Register::T1, imm: -43},
-            changes: {registers: {t1: 42}},
-            to: {registers: {t1: 42, t4: 0}, pc: 4},
+            executed_on: {registers: {t1: 42}},
+            results_in: {registers: {t1: 42, t4: 0}, pc: 4},
         );
     }
 
@@ -432,28 +432,28 @@ mod test {
     fn execute_sltiu() {
         test_execute!(
             Instruction::SLTIU{rd: Register::T4, rs1: Register::T1, imm: 43},
-            changes: {registers: {t1: 42}},
-            to: {registers: {t1: 42, t4: 1}, pc: 4},
+            executed_on: {registers: {t1: 42}},
+            results_in: {registers: {t1: 42, t4: 1}, pc: 4},
         );
         test_execute!(
             Instruction::SLTIU{rd: Register::T4, rs1: Register::T1, imm: 42},
-            changes: {registers: {t1: 42, t4: 100}},
-            to: {registers: {t1: 42, t4: 0}, pc: 4},
+            executed_on: {registers: {t1: 42, t4: 100}},
+            results_in: {registers: {t1: 42, t4: 0}, pc: 4},
         );
         test_execute!(
             Instruction::SLTIU{rd: Register::T4, rs1: Register::T1, imm: -43},
-            changes: {registers: {t1: 42}},
-            to: {registers: {t1: 42, t4: 1}, pc: 4},
+            executed_on: {registers: {t1: 42}},
+            results_in: {registers: {t1: 42, t4: 1}, pc: 4},
         );
         test_execute!(
             Instruction::SLTIU{rd: Register::T4, rs1: Register::T1, imm: 1},
-            changes: {registers: {t1: 42}},
-            to: {registers: {t1: 42, t4: 0}, pc: 4},
+            executed_on: {registers: {t1: 42}},
+            results_in: {registers: {t1: 42, t4: 0}, pc: 4},
         );
         test_execute!(
             Instruction::SLTIU{rd: Register::T4, rs1: Register::T1, imm: 1},
-            changes: {registers: {t1: 0}},
-            to: {registers: {t1: 0, t4: 1}, pc: 4},
+            executed_on: {registers: {t1: 0}},
+            results_in: {registers: {t1: 0, t4: 1}, pc: 4},
         );
     }
 
@@ -461,13 +461,13 @@ mod test {
     fn execute_xori() {
         test_execute!(
             Instruction::XORI{rd: Register::A0, rs1: Register::A1, imm: -1},
-            changes: {registers: {a1: 42}},
-            to: {registers: {a0: !(42), a1: 42}, pc: 4},
+            executed_on: {registers: {a1: 42}},
+            results_in: {registers: {a0: !(42), a1: 42}, pc: 4},
         );
         test_execute!(
             Instruction::XORI{rd: Register::A2, rs1: Register::A3, imm: 1},
-            changes: {registers: {a3: 2}},
-            to: {registers: {a2: 3, a3: 2}, pc: 4},
+            executed_on: {registers: {a3: 2}},
+            results_in: {registers: {a2: 3, a3: 2}, pc: 4},
         );
     }
 
@@ -475,23 +475,23 @@ mod test {
     fn execute_ori() {
         test_execute!(
             Instruction::ORI{rd: Register::S0, rs1: Register::S1, imm: -1},
-            changes: {registers: {s1: 42}},
-            to: {registers: {s0: -1, s1: 42}, pc: 4},
+            executed_on: {registers: {s1: 42}},
+            results_in: {registers: {s0: -1, s1: 42}, pc: 4},
         );
         test_execute!(
             Instruction::ORI{rd: Register::S2, rs1: Register::S3, imm: 2},
-            changes: {registers: {s3: 2}},
-            to: {registers: {s2: 2, s3: 2}, pc: 4},
+            executed_on: {registers: {s3: 2}},
+            results_in: {registers: {s2: 2, s3: 2}, pc: 4},
         );
         test_execute!(
             Instruction::ORI{rd: Register::S4, rs1: Register::S5, imm: 8},
-            changes: {registers: {s5: 3}},
-            to: {registers: {s4: 11, s5: 3}, pc: 4},
+            executed_on: {registers: {s5: 3}},
+            results_in: {registers: {s4: 11, s5: 3}, pc: 4},
         );
         test_execute!(
             Instruction::ORI{rd: Register::S4, rs1: Register::S5, imm: 7},
-            changes: {registers: {s5: 19}},
-            to: {registers: {s4: 23, s5: 19}, pc: 4},
+            executed_on: {registers: {s5: 19}},
+            results_in: {registers: {s4: 23, s5: 19}, pc: 4},
         );
     }
 
@@ -499,23 +499,23 @@ mod test {
     fn execute_andi() {
         test_execute!(
             Instruction::ANDI{rd: Register::S0, rs1: Register::S1, imm: -1},
-            changes: {registers: {s1: 42}},
-            to: {registers: {s0: 42, s1: 42}, pc: 4},
+            executed_on: {registers: {s1: 42}},
+            results_in: {registers: {s0: 42, s1: 42}, pc: 4},
         );
         test_execute!(
             Instruction::ANDI{rd: Register::S2, rs1: Register::S3, imm: 2},
-            changes: {registers: {s3: 2}},
-            to: {registers: {s2: 2, s3: 2}, pc: 4},
+            executed_on: {registers: {s3: 2}},
+            results_in: {registers: {s2: 2, s3: 2}, pc: 4},
         );
         test_execute!(
             Instruction::ANDI{rd: Register::S4, rs1: Register::S5, imm: 8},
-            changes: {registers: {s5: 3}},
-            to: {registers: {s4: 0, s5: 3}, pc: 4},
+            executed_on: {registers: {s5: 3}},
+            results_in: {registers: {s4: 0, s5: 3}, pc: 4},
         );
         test_execute!(
             Instruction::ANDI{rd: Register::S4, rs1: Register::S5, imm: 7},
-            changes: {registers: {s5: 19}},
-            to: {registers: {s4: 3, s5: 19}, pc: 4},
+            executed_on: {registers: {s5: 19}},
+            results_in: {registers: {s4: 3, s5: 19}, pc: 4},
         );
     }
 
@@ -523,23 +523,23 @@ mod test {
     fn execute_slli() {
         test_execute!(
             Instruction::SLLI{rd: Register::SP, rs1: Register::RA, shamt: 5},
-            changes: {registers: {ra: 1}},
-            to: {registers: {sp: 32, ra: 1}, pc: 4},
+            executed_on: {registers: {ra: 1}},
+            results_in: {registers: {sp: 32, ra: 1}, pc: 4},
         );
         test_execute!(
             Instruction::SLLI{rd: Register::SP, rs1: Register::RA, shamt: 20},
-            changes: {registers: {ra: 0}},
-            to: {registers: {sp: 0, ra: 0}, pc: 4},
+            executed_on: {registers: {ra: 0}},
+            results_in: {registers: {sp: 0, ra: 0}, pc: 4},
         );
         test_execute!(
             Instruction::SLLI{rd: Register::SP, rs1: Register::RA, shamt: 1},
-            changes: {registers: {ra: i32::MAX}},
-            to: {registers: {sp: -2, ra: i32::MAX}, pc: 4},
+            executed_on: {registers: {ra: i32::MAX}},
+            results_in: {registers: {sp: -2, ra: i32::MAX}, pc: 4},
         );
         test_execute!(
             Instruction::SLLI{rd: Register::SP, rs1: Register::RA, shamt: 2},
-            changes: {registers: {ra: 2 << 29}},
-            to: {registers: {sp: 0, ra: 2 << 29}, pc: 4},
+            executed_on: {registers: {ra: 2 << 29}},
+            results_in: {registers: {sp: 0, ra: 2 << 29}, pc: 4},
         );
     }
 
@@ -547,28 +547,28 @@ mod test {
     fn execute_srli() {
         test_execute!(
             Instruction::SRLI{rd: Register::SP, rs1: Register::RA, shamt: 5},
-            changes: {registers: {ra: 64}},
-            to: {registers: {sp: 2, ra: 64}, pc: 4},
+            executed_on: {registers: {ra: 64}},
+            results_in: {registers: {sp: 2, ra: 64}, pc: 4},
         );
         test_execute!(
             Instruction::SRLI{rd: Register::SP, rs1: Register::RA, shamt: 20},
-            changes: {registers: {ra: 0}},
-            to: {registers: {sp: 0, ra: 0}, pc: 4},
+            executed_on: {registers: {ra: 0}},
+            results_in: {registers: {sp: 0, ra: 0}, pc: 4},
         );
         test_execute!(
             Instruction::SRLI{rd: Register::SP, rs1: Register::RA, shamt: 1},
-            changes: {registers: {ra: -1}},
-            to: {registers: {sp: i32::MAX, ra: -1}, pc: 4},
+            executed_on: {registers: {ra: -1}},
+            results_in: {registers: {sp: i32::MAX, ra: -1}, pc: 4},
         );
         test_execute!(
             Instruction::SRLI{rd: Register::SP, rs1: Register::RA, shamt: 1},
-            changes: {registers: {ra: -1000}},
-            to: {registers: {sp: 2147483148, ra: -1000}, pc: 4},
+            executed_on: {registers: {ra: -1000}},
+            results_in: {registers: {sp: 2147483148, ra: -1000}, pc: 4},
         );
         test_execute!(
             Instruction::SRLI{rd: Register::SP, rs1: Register::RA, shamt: 2},
-            changes: {registers: {ra: 42}},
-            to: {registers: {sp: 10, ra: 42}, pc: 4},
+            executed_on: {registers: {ra: 42}},
+            results_in: {registers: {sp: 10, ra: 42}, pc: 4},
         );
     }
 
@@ -576,28 +576,28 @@ mod test {
     fn execute_srai() {
         test_execute!(
             Instruction::SRAI{rd: Register::SP, rs1: Register::RA, shamt: 5},
-            changes: {registers: {ra: 64}},
-            to: {registers: {sp: 2, ra: 64}, pc: 4},
+            executed_on: {registers: {ra: 64}},
+            results_in: {registers: {sp: 2, ra: 64}, pc: 4},
         );
         test_execute!(
             Instruction::SRAI{rd: Register::SP, rs1: Register::RA, shamt: 20},
-            changes: {registers: {ra: 0}},
-            to: {registers: {sp: 0, ra: 0}, pc: 4},
+            executed_on: {registers: {ra: 0}},
+            results_in: {registers: {sp: 0, ra: 0}, pc: 4},
         );
         test_execute!(
             Instruction::SRAI{rd: Register::SP, rs1: Register::RA, shamt: 10},
-            changes: {registers: {ra: -1}},
-            to: {registers: {sp: -1, ra: -1}, pc: 4},
+            executed_on: {registers: {ra: -1}},
+            results_in: {registers: {sp: -1, ra: -1}, pc: 4},
         );
         test_execute!(
             Instruction::SRAI{rd: Register::SP, rs1: Register::RA, shamt: 4},
-            changes: {registers: {ra: -1000}},
-            to: {registers: {sp: -63, ra: -1000}, pc: 4},
+            executed_on: {registers: {ra: -1000}},
+            results_in: {registers: {sp: -63, ra: -1000}, pc: 4},
         );
         test_execute!(
             Instruction::SRAI{rd: Register::SP, rs1: Register::RA, shamt: 2},
-            changes: {registers: {ra: 42}},
-            to: {registers: {sp: 10, ra: 42}, pc: 4},
+            executed_on: {registers: {ra: 42}},
+            results_in: {registers: {sp: 10, ra: 42}, pc: 4},
         );
     }
 
@@ -605,8 +605,8 @@ mod test {
     fn execute_add() {
         test_execute!(
             Instruction::ADD{rd: Register::T3, rs1: Register::T1, rs2: Register::T2},
-            changes: {registers: {t1: 21, t2: 21}},
-            to: {registers: {t1: 21, t2: 21, t3: 42}, pc: 4},
+            executed_on: {registers: {t1: 21, t2: 21}},
+            results_in: {registers: {t1: 21, t2: 21, t3: 42}, pc: 4},
         );
     }
 
@@ -614,8 +614,8 @@ mod test {
     fn execute_sub() {
         test_execute!(
             Instruction::SUB { rd: Register::T3, rs1: Register::T1, rs2: Register::T2, },
-            changes: {registers: {t1: 45, t2: 3}},
-            to: {registers: {t1: 45, t2: 3, t3: 42}, pc: 4},
+            executed_on: {registers: {t1: 45, t2: 3}},
+            results_in: {registers: {t1: 45, t2: 3, t3: 42}, pc: 4},
         );
     }
 
@@ -623,23 +623,23 @@ mod test {
     fn execute_sll() {
         test_execute!(
             Instruction::SLL{rd: Register::T4, rs1: Register::T5, rs2: Register::T6},
-            changes: {registers: {t5: 0, t6: 4}},
-            to: {registers: {t4: 0, t5: 0, t6: 4}, pc: 4},
+            executed_on: {registers: {t5: 0, t6: 4}},
+            results_in: {registers: {t4: 0, t5: 0, t6: 4}, pc: 4},
         );
         test_execute!(
             Instruction::SLL{rd: Register::S1, rs1: Register::S2, rs2: Register::S3},
-            changes: {registers: {s1: 100, s2: 1, s3: 63}},
-            to: {registers: {s1: i32::MIN, s2: 1, s3: 63}, pc: 4},
+            executed_on: {registers: {s1: 100, s2: 1, s3: 63}},
+            results_in: {registers: {s1: i32::MIN, s2: 1, s3: 63}, pc: 4},
         );
         test_execute!(
             Instruction::SLL{rd: Register::S4, rs1: Register::S5, rs2: Register::S6},
-            changes: {registers: {s4: 100, s5: i32::MAX, s6: 1}},
-            to: {registers: {s4: -2, s5: i32::MAX, s6: 1}, pc: 4},
+            executed_on: {registers: {s4: 100, s5: i32::MAX, s6: 1}},
+            results_in: {registers: {s4: -2, s5: i32::MAX, s6: 1}, pc: 4},
         );
         test_execute!(
             Instruction::SLL{rd: Register::S7, rs1: Register::S8, rs2: Register::S9},
-            changes: {registers: {s7: 100, s8: 2 << 29, s9: 2}},
-            to: {registers: {s7: 0, s8: 2 << 29, s9: 2}, pc: 4},
+            executed_on: {registers: {s7: 100, s8: 2 << 29, s9: 2}},
+            results_in: {registers: {s7: 0, s8: 2 << 29, s9: 2}, pc: 4},
         );
     }
 
@@ -647,18 +647,18 @@ mod test {
     fn execute_slt() {
         test_execute!(
             Instruction::SLT{rd: Register::T4, rs1: Register::T1, rs2: Register::T3},
-            changes: {registers: {t1: 42, t3: 43}},
-            to: {registers: {t1: 42, t4: 1, t3: 43}, pc: 4},
+            executed_on: {registers: {t1: 42, t3: 43}},
+            results_in: {registers: {t1: 42, t4: 1, t3: 43}, pc: 4},
         );
         test_execute!(
             Instruction::SLT{rd: Register::T4, rs1: Register::T1, rs2: Register::T3},
-            changes: {registers: {t1: 42, t4: 100, t3: 42}},
-            to: {registers: {t1: 42, t4: 0, t3: 42}, pc: 4},
+            executed_on: {registers: {t1: 42, t4: 100, t3: 42}},
+            results_in: {registers: {t1: 42, t4: 0, t3: 42}, pc: 4},
         );
         test_execute!(
             Instruction::SLT{rd: Register::T4, rs1: Register::T1, rs2: Register::T3},
-            changes: {registers: {t1: 42, t3: -43}},
-            to: {registers: {t1: 42, t4: 0, t3: -43}, pc: 4},
+            executed_on: {registers: {t1: 42, t3: -43}},
+            results_in: {registers: {t1: 42, t4: 0, t3: -43}, pc: 4},
         );
     }
 
@@ -666,28 +666,28 @@ mod test {
     fn execute_sltu() {
         test_execute!(
             Instruction::SLTU{rd: Register::T4, rs1: Register::T1, rs2: Register::A4},
-            changes: {registers: {t1: 42, a4: 43}},
-            to: {registers: {t1: 42, t4: 1, a4: 43}, pc: 4},
+            executed_on: {registers: {t1: 42, a4: 43}},
+            results_in: {registers: {t1: 42, t4: 1, a4: 43}, pc: 4},
         );
         test_execute!(
             Instruction::SLTU{rd: Register::T4, rs1: Register::T1, rs2: Register::A4},
-            changes: {registers: {t1: 42, t4: 100, a4: 42}},
-            to: {registers: {t1: 42, t4: 0, a4: 42}, pc: 4},
+            executed_on: {registers: {t1: 42, t4: 100, a4: 42}},
+            results_in: {registers: {t1: 42, t4: 0, a4: 42}, pc: 4},
         );
         test_execute!(
             Instruction::SLTU{rd: Register::T4, rs1: Register::T1, rs2: Register::A4},
-            changes: {registers: {t1: 42, a4: -43}},
-            to: {registers: {t1: 42, t4: 1, a4: -43}, pc: 4},
+            executed_on: {registers: {t1: 42, a4: -43}},
+            results_in: {registers: {t1: 42, t4: 1, a4: -43}, pc: 4},
         );
         test_execute!(
             Instruction::SLTU{rd: Register::T4, rs1: Register::T1, rs2: Register::A4},
-            changes: {registers: {t1: 42, a4: 1}},
-            to: {registers: {t1: 42, t4: 0, a4: 1}, pc: 4},
+            executed_on: {registers: {t1: 42, a4: 1}},
+            results_in: {registers: {t1: 42, t4: 0, a4: 1}, pc: 4},
         );
         test_execute!(
             Instruction::SLTU{rd: Register::T4, rs1: Register::T1, rs2: Register::A4},
-            changes: {registers: {t1: 0, a4: 1}},
-            to: {registers: {t1: 0, t4: 1, a4: 1}, pc: 4},
+            executed_on: {registers: {t1: 0, a4: 1}},
+            results_in: {registers: {t1: 0, t4: 1, a4: 1}, pc: 4},
         );
     }
 
@@ -695,23 +695,23 @@ mod test {
     fn execute_or() {
         test_execute!(
             Instruction::OR{rd: Register::S0, rs1: Register::S1, rs2: Register::T2},
-            changes: {registers: {s1: 42, t2: -1}},
-            to: {registers: {s0: -1, s1: 42, t2: -1}, pc: 4},
+            executed_on: {registers: {s1: 42, t2: -1}},
+            results_in: {registers: {s0: -1, s1: 42, t2: -1}, pc: 4},
         );
         test_execute!(
             Instruction::OR{rd: Register::S2, rs1: Register::S3, rs2: Register::T3},
-            changes: {registers: {s3: 2, t3: 2}},
-            to: {registers: {s2: 2, s3: 2, t3: 2}, pc: 4},
+            executed_on: {registers: {s3: 2, t3: 2}},
+            results_in: {registers: {s2: 2, s3: 2, t3: 2}, pc: 4},
         );
         test_execute!(
             Instruction::OR{rd: Register::S4, rs1: Register::S5, rs2: Register::T4},
-            changes: {registers: {s5: 3, t4: 8}},
-            to: {registers: {s4: 11, s5: 3, t4: 8}, pc: 4},
+            executed_on: {registers: {s5: 3, t4: 8}},
+            results_in: {registers: {s4: 11, s5: 3, t4: 8}, pc: 4},
         );
         test_execute!(
             Instruction::OR{rd: Register::S4, rs1: Register::S5, rs2: Register::T5},
-            changes: {registers: {s5: 19, t5: 7}},
-            to: {registers: {s4: 23, s5: 19, t5: 7}, pc: 4},
+            executed_on: {registers: {s5: 19, t5: 7}},
+            results_in: {registers: {s4: 23, s5: 19, t5: 7}, pc: 4},
         );
     }
 
@@ -719,28 +719,28 @@ mod test {
     fn execute_srl() {
         test_execute!(
             Instruction::SRL{rd: Register::S10, rs1: Register::S11, rs2: Register::A0},
-            changes: {registers: {s10: 100, s11: 64, a0: 5}},
-            to: {registers: {s10: 2, s11: 64, a0: 5}, pc: 4},
+            executed_on: {registers: {s10: 100, s11: 64, a0: 5}},
+            results_in: {registers: {s10: 2, s11: 64, a0: 5}, pc: 4},
         );
         test_execute!(
             Instruction::SRL{rd: Register::A1, rs1: Register::A2, rs2: Register::A3},
-            changes: {registers: {a1: 100, a2: -1, a3: 1}},
-            to: {registers: {a1: i32::MAX, a2: -1, a3: 1}, pc: 4},
+            executed_on: {registers: {a1: 100, a2: -1, a3: 1}},
+            results_in: {registers: {a1: i32::MAX, a2: -1, a3: 1}, pc: 4},
         );
         test_execute!(
             Instruction::SRL{rd: Register::A4, rs1: Register::A5, rs2: Register::A6},
-            changes: {registers: {a4: 100, a5: -1000, a6: 1}},
-            to: {registers: {a4: 2147483148, a5: -1000, a6: 1}, pc: 4},
+            executed_on: {registers: {a4: 100, a5: -1000, a6: 1}},
+            results_in: {registers: {a4: 2147483148, a5: -1000, a6: 1}, pc: 4},
         );
         test_execute!(
             Instruction::SRL{rd: Register::A4, rs1: Register::A5, rs2: Register::A6},
-            changes: {registers: {a4: 100, a5: i32::MIN, a6: 63}},
-            to: {registers: {a4: 1, a5: i32::MIN, a6: 63}, pc: 4},
+            executed_on: {registers: {a4: 100, a5: i32::MIN, a6: 63}},
+            results_in: {registers: {a4: 1, a5: i32::MIN, a6: 63}, pc: 4},
         );
         test_execute!(
             Instruction::SRL{rd: Register::A7, rs1: Register::A2, rs2: Register::A3},
-            changes: {registers: {a7: 100, a2: 42, a3: 2}},
-            to: {registers: {a7: 10, a2: 42, a3: 2}, pc: 4},
+            executed_on: {registers: {a7: 100, a2: 42, a3: 2}},
+            results_in: {registers: {a7: 10, a2: 42, a3: 2}, pc: 4},
         );
     }
 
@@ -748,33 +748,33 @@ mod test {
     fn execute_sra() {
         test_execute!(
             Instruction::SRA{rd: Register::T0, rs1: Register::T1, rs2: Register::T2},
-            changes: {registers: {t0: 100, t1: 64, t2: 5}},
-            to: {registers: {t0: 2, t1: 64, t2: 5}, pc: 4},
+            executed_on: {registers: {t0: 100, t1: 64, t2: 5}},
+            results_in: {registers: {t0: 2, t1: 64, t2: 5}, pc: 4},
         );
         test_execute!(
             Instruction::SRA{rd: Register::T3, rs1: Register::T4, rs2: Register::T5},
-            changes: {registers: {t3: 100, t4: 0, t5: 20}},
-            to: {registers: {t3: 0, t4: 0, t5: 20}, pc: 4},
+            executed_on: {registers: {t3: 100, t4: 0, t5: 20}},
+            results_in: {registers: {t3: 0, t4: 0, t5: 20}, pc: 4},
         );
         test_execute!(
             Instruction::SRA{rd: Register::T6, rs1: Register::S0, rs2: Register::TP},
-            changes: {registers: {t6: 100, s0: -1, tp: 10}},
-            to: {registers: {t6: -1, s0: -1, tp: 10}, pc: 4},
+            executed_on: {registers: {t6: 100, s0: -1, tp: 10}},
+            results_in: {registers: {t6: -1, s0: -1, tp: 10}, pc: 4},
         );
         test_execute!(
             Instruction::SRA{rd: Register::A4, rs1: Register::A5, rs2: Register::A6},
-            changes: {registers: {a4: 100, a5: i32::MIN, a6: 63}},
-            to: {registers: {a4: -1, a5: i32::MIN, a6: 63}, pc: 4},
+            executed_on: {registers: {a4: 100, a5: i32::MIN, a6: 63}},
+            results_in: {registers: {a4: -1, a5: i32::MIN, a6: 63}, pc: 4},
         );
         test_execute!(
             Instruction::SRA{rd: Register::GP, rs1: Register::SP, rs2: Register::RA},
-            changes: {registers: {gp: 100, sp: -1000, ra: 4}},
-            to: {registers: {gp: -63, sp: -1000, ra: 4}, pc: 4},
+            executed_on: {registers: {gp: 100, sp: -1000, ra: 4}},
+            results_in: {registers: {gp: -63, sp: -1000, ra: 4}, pc: 4},
         );
         test_execute!(
             Instruction::SRA{rd: Register::GP, rs1: Register::SP, rs2: Register::RA},
-            changes: {registers: {gp: 100, sp: 42, ra: 2}},
-            to: {registers: {gp: 10, sp: 42, ra: 2}, pc: 4},
+            executed_on: {registers: {gp: 100, sp: 42, ra: 2}},
+            results_in: {registers: {gp: 10, sp: 42, ra: 2}, pc: 4},
         );
     }
 
@@ -782,13 +782,13 @@ mod test {
     fn execute_xor() {
         test_execute!(
             Instruction::XOR{rd: Register::A0, rs1: Register::A1, rs2: Register::A2},
-            changes: {registers: {a1: 42, a2: -1}},
-            to: {registers: {a0: !(42), a1: 42, a2: -1}, pc: 4},
+            executed_on: {registers: {a1: 42, a2: -1}},
+            results_in: {registers: {a0: !(42), a1: 42, a2: -1}, pc: 4},
         );
         test_execute!(
             Instruction::XOR{rd: Register::A2, rs1: Register::A3, rs2: Register::A4},
-            changes: {registers: {a3: 2, a4: 1}},
-            to: {registers: {a2: 3, a3: 2, a4: 1}, pc: 4},
+            executed_on: {registers: {a3: 2, a4: 1}},
+            results_in: {registers: {a2: 3, a3: 2, a4: 1}, pc: 4},
         );
     }
 
@@ -796,23 +796,23 @@ mod test {
     fn execute_and() {
         test_execute!(
             Instruction::AND{rd: Register::S0, rs1: Register::S1, rs2: Register::A1},
-            changes: {registers: {s1: 42, a1: -1}},
-            to: {registers: {s0: 42, s1: 42, a1: -1}, pc: 4},
+            executed_on: {registers: {s1: 42, a1: -1}},
+            results_in: {registers: {s0: 42, s1: 42, a1: -1}, pc: 4},
         );
         test_execute!(
             Instruction::AND{rd: Register::S2, rs1: Register::S3, rs2: Register::A2},
-            changes: {registers: {s3: 2, a2: 2}},
-            to: {registers: {s2: 2, s3: 2, a2: 2}, pc: 4},
+            executed_on: {registers: {s3: 2, a2: 2}},
+            results_in: {registers: {s2: 2, s3: 2, a2: 2}, pc: 4},
         );
         test_execute!(
             Instruction::AND{rd: Register::S4, rs1: Register::S5, rs2: Register::A3},
-            changes: {registers: {s5: 3, a3: 8}},
-            to: {registers: {s4: 0, s5: 3, a3: 8}, pc: 4},
+            executed_on: {registers: {s5: 3, a3: 8}},
+            results_in: {registers: {s4: 0, s5: 3, a3: 8}, pc: 4},
         );
         test_execute!(
             Instruction::AND{rd: Register::S4, rs1: Register::S5, rs2: Register::A4},
-            changes: {registers: {s5: 19, a4: 7}},
-            to: {registers: {s4: 3, s5: 19, a4: 7}, pc: 4},
+            executed_on: {registers: {s5: 19, a4: 7}},
+            results_in: {registers: {s4: 3, s5: 19, a4: 7}, pc: 4},
         );
     }
 
@@ -820,13 +820,13 @@ mod test {
     fn execute_lb() {
         test_execute!(
             Instruction::LB { rd: Register::T3, rs1: Register::T1, offset: 31, },
-            changes: {registers: {t1: 0}, memory: {31: 21}},
-            to: {registers: {t3: 21}, memory: {31: 21}, pc: 4},
+            executed_on: {registers: {t1: 0}, memory: {31: 21}},
+            results_in: {registers: {t3: 21}, memory: {31: 21}, pc: 4},
         );
         test_execute!(
             Instruction::LB { rd: Register::T3, rs1: Register::T1, offset: 31, },
-            changes: {registers: {t1:0}, memory: {31: -1}},
-            to: {registers: {t3: -1}, memory: {31: -1}, pc: 4},
+            executed_on: {registers: {t1:0}, memory: {31: -1}},
+            results_in: {registers: {t3: -1}, memory: {31: -1}, pc: 4},
         );
     }
 
@@ -834,13 +834,13 @@ mod test {
     fn execute_lh() {
         test_execute!(
             Instruction::LH { rd: Register::T3, rs1: Register::T1, offset: 21, },
-            changes: {registers: {t1: 21}, memory: {42: 12}},
-            to: {registers: {t1: 21, t3: 12}, memory: {42: 12}, pc: 4},
+            executed_on: {registers: {t1: 21}, memory: {42: 12}},
+            results_in: {registers: {t1: 21, t3: 12}, memory: {42: 12}, pc: 4},
         );
         test_execute!(
             Instruction::LH { rd: Register::T3, rs1: Register::T1, offset: 21, },
-            changes: {registers: {t1: 21}, memory: {42: -12}},
-            to: {registers: {t1: 21, t3: -12}, memory: {42: -12}, pc: 4},
+            executed_on: {registers: {t1: 21}, memory: {42: -12}},
+            results_in: {registers: {t1: 21, t3: -12}, memory: {42: -12}, pc: 4},
         );
     }
 
@@ -848,8 +848,8 @@ mod test {
     fn execute_lw() {
         test_execute!(
             Instruction::LW { rd: Register::T3, rs1: Register::T1, offset: 31, },
-            changes: {registers: {t1: 3}, memory: {34: 12}},
-            to: {registers: {t1: 3, t3: 12}, memory: {34: 12}, pc: 4},
+            executed_on: {registers: {t1: 3}, memory: {34: 12}},
+            results_in: {registers: {t1: 3, t3: 12}, memory: {34: 12}, pc: 4},
         );
     }
 
@@ -857,13 +857,13 @@ mod test {
     fn execute_lbu() {
         test_execute!(
             Instruction::LBU { rd: Register::T3, rs1: Register::T1, offset: 31, },
-            changes: {registers: {t1: 0}, memory: {31: 21}},
-            to: {registers: {t3: 21}, memory: {31: 21}, pc: 4},
+            executed_on: {registers: {t1: 0}, memory: {31: 21}},
+            results_in: {registers: {t3: 21}, memory: {31: 21}, pc: 4},
         );
         test_execute!(
             Instruction::LBU { rd: Register::T3, rs1: Register::T1, offset: 31, },
-            changes: {registers: {t1:0}, memory: {31: -1}},
-            to: {registers: {t3: u8::MAX as i32}, memory: {31: -1}, pc: 4},
+            executed_on: {registers: {t1:0}, memory: {31: -1}},
+            results_in: {registers: {t3: u8::MAX as i32}, memory: {31: -1}, pc: 4},
         );
     }
 
@@ -871,13 +871,13 @@ mod test {
     fn execute_lhu() {
         test_execute!(
             Instruction::LHU { rd: Register::T3, rs1: Register::T1, offset: 21, },
-            changes: {registers: {t1: 21}, memory: {42: 12}},
-            to: {registers: {t1: 21, t3: 12}, memory: {42: 12}, pc: 4},
+            executed_on: {registers: {t1: 21}, memory: {42: 12}},
+            results_in: {registers: {t1: 21, t3: 12}, memory: {42: 12}, pc: 4},
         );
         test_execute!(
             Instruction::LHU { rd: Register::T3, rs1: Register::T1, offset: 21, },
-            changes: {registers: {t1: 21}, memory: {42: -1}},
-            to: {registers: {t1: 21, t3: u16::MAX as i32}, memory: {42: -1}, pc: 4},
+            executed_on: {registers: {t1: 21}, memory: {42: -1}},
+            results_in: {registers: {t1: 21, t3: u16::MAX as i32}, memory: {42: -1}, pc: 4},
         );
     }
 
@@ -885,13 +885,13 @@ mod test {
     fn execute_sb() {
         test_execute!(
             Instruction::SB { rs1: Register::T1, rs2: Register::T3, offset: 0, },
-            changes: {registers: {t1: 0, t3: 21}, memory: {4: 1}},
-            to: {registers: {t3: 21}, memory: {0: 21, 4: 1}, pc: 4},
+            executed_on: {registers: {t1: 0, t3: 21}, memory: {4: 1}},
+            results_in: {registers: {t3: 21}, memory: {0: 21, 4: 1}, pc: 4},
         );
         test_execute!(
             Instruction::SB { rs1: Register::T1, rs2: Register::T3, offset: 31, },
-            changes: {registers: {t1:0, t3: -1}, memory: {32: 0}},
-            to: {registers: {t3: -1}, memory: {31: -1, 32: 0}, pc: 4},
+            executed_on: {registers: {t1:0, t3: -1}, memory: {32: 0}},
+            results_in: {registers: {t3: -1}, memory: {31: -1, 32: 0}, pc: 4},
         );
     }
 
@@ -899,13 +899,13 @@ mod test {
     fn execute_sh() {
         test_execute!(
             Instruction::SH { rs1: Register::T1, rs2: Register::T3, offset: 21, },
-            changes: {registers: {t1: 21, t3: 12}, memory: {44: 1}},
-            to: {registers: {t1: 21, t3: 12}, memory: {42: 12, 44: 1}, pc: 4},
+            executed_on: {registers: {t1: 21, t3: 12}, memory: {44: 1}},
+            results_in: {registers: {t1: 21, t3: 12}, memory: {42: 12, 44: 1}, pc: 4},
         );
         test_execute!(
             Instruction::SH { rs1: Register::T1, rs2: Register::T3, offset: 21, },
-            changes: {registers: {t1: 21, t3: -12}, memory: {44: 0}},
-            to: {registers: {t1: 21, t3: -12}, memory: {42: -12, 44: 0}, pc: 4},
+            executed_on: {registers: {t1: 21, t3: -12}, memory: {44: 0}},
+            results_in: {registers: {t1: 21, t3: -12}, memory: {42: -12, 44: 0}, pc: 4},
         );
     }
 
@@ -913,8 +913,8 @@ mod test {
     fn execute_sw() {
         test_execute!(
             Instruction::SW {  rs1: Register::T1,rs2: Register::T3, offset: 31, },
-            changes: {registers: {t1: 3, t3: 12}},
-            to: {registers: {t1: 3, t3: 12}, memory: {34: 12}, pc: 4},
+            executed_on: {registers: {t1: 3, t3: 12}},
+            results_in: {registers: {t1: 3, t3: 12}, memory: {34: 12}, pc: 4},
         );
     }
 
@@ -922,13 +922,13 @@ mod test {
     fn execute_csrrw() {
         test_execute!(
             Instruction::CSRRW { rd: Register::A0, rs1: Register::S10, csr: 20 },
-            changes: {registers: {a0: 3, s10: 12}},
-            to: {registers: {a0: 0, s10: 12}, csr: {20: 12}, pc: 4},
+            executed_on: {registers: {a0: 3, s10: 12}},
+            results_in: {registers: {a0: 0, s10: 12}, csr: {20: 12}, pc: 4},
         );
         test_execute!(
             Instruction::CSRRW { rd: Register::T1, rs1: Register::T0, csr: 5 },
-            changes: {registers: {t1: 3, t0: 12}, csr: {5: 42}},
-            to: {registers: {t1: 42, t0: 12}, csr: {5: 12}, pc: 4},
+            executed_on: {registers: {t1: 3, t0: 12}, csr: {5: 42}},
+            results_in: {registers: {t1: 42, t0: 12}, csr: {5: 12}, pc: 4},
         );
     }
 
@@ -936,13 +936,13 @@ mod test {
     fn execute_csrr() {
         test_execute!(
             Instruction::CSRR(Register::S3, 42),
-            changes: {registers: {s3: 0}},
-            to: {registers: {s3: 0}, pc: 4},
+            executed_on: {registers: {s3: 0}},
+            results_in: {registers: {s3: 0}, pc: 4},
         );
         test_execute!(
             Instruction::CSRR(Register::S6, 42),
-            changes: {registers: {s6: 3}, csr: {42: 42}},
-            to: {registers: {s6: 42}, csr: {42: 42}, pc: 4},
+            executed_on: {registers: {s6: 3}, csr: {42: 42}},
+            results_in: {registers: {s6: 42}, csr: {42: 42}, pc: 4},
         );
     }
 
@@ -950,13 +950,13 @@ mod test {
     fn execute_csrw() {
         test_execute!(
             Instruction::CSRW(Register::S3, 42),
-            changes: {registers: {s3: 0}},
-            to: {registers: {s3: 0}, pc: 4},
+            executed_on: {registers: {s3: 0}},
+            results_in: {registers: {s3: 0}, pc: 4},
         );
         test_execute!(
             Instruction::CSRW(Register::S6, 42),
-            changes: {registers: {s6: 3}, csr: {42: 42}},
-            to: {registers: {s6: 3}, csr: {42: 3}, pc: 4},
+            executed_on: {registers: {s6: 3}, csr: {42: 42}},
+            results_in: {registers: {s6: 3}, csr: {42: 3}, pc: 4},
         );
     }
 
@@ -964,18 +964,18 @@ mod test {
     fn execute_csrrs() {
         test_execute!(
             Instruction::CSRRS { rd: Register::T2, rs1: Register::S4, csr: 20 },
-            changes: {registers: {t2: 3, s4: 12}},
-            to: {registers: {t2: 0, s4: 12}, csr: {20: 12}, pc: 4},
+            executed_on: {registers: {t2: 3, s4: 12}},
+            results_in: {registers: {t2: 0, s4: 12}, csr: {20: 12}, pc: 4},
         );
         test_execute!(
             Instruction::CSRRS { rd: Register::S8, rs1: Register::ZERO, csr: 20 },
-            changes: {registers: {s8: 3}, csr: {20: 12}},
-            to: {registers: {s8: 12}, csr: {20: 12}, pc: 4},
+            executed_on: {registers: {s8: 3}, csr: {20: 12}},
+            results_in: {registers: {s8: 12}, csr: {20: 12}, pc: 4},
         );
         test_execute!(
             Instruction::CSRRS { rd: Register::A6, rs1: Register::S7, csr: 5 },
-            changes: {registers: {a6: 3, s7: 0b10010010}, csr: {5: 0b10000101}},
-            to: {registers: {a6: 0b10000101, s7: 0b10010010}, csr: {5: 0b10010111}, pc: 4},
+            executed_on: {registers: {a6: 3, s7: 0b10010010}, csr: {5: 0b10000101}},
+            results_in: {registers: {a6: 0b10000101, s7: 0b10010010}, csr: {5: 0b10010111}, pc: 4},
         );
     }
 
@@ -983,18 +983,18 @@ mod test {
     fn execute_csrrc() {
         test_execute!(
             Instruction::CSRRC { rd: Register::RA, rs1: Register::GP, csr: 20 },
-            changes: {registers: {ra: 3, gp: 12}},
-            to: {registers: {ra: 0, gp: 12}, pc: 4},
+            executed_on: {registers: {ra: 3, gp: 12}},
+            results_in: {registers: {ra: 0, gp: 12}, pc: 4},
         );
         test_execute!(
             Instruction::CSRRS { rd: Register::S9, rs1: Register::ZERO, csr: 20 },
-            changes: {registers: {s9: 30}, csr: {20: 12}},
-            to: {registers: {s9: 12}, csr: {20: 12}, pc: 4},
+            executed_on: {registers: {s9: 30}, csr: {20: 12}},
+            results_in: {registers: {s9: 12}, csr: {20: 12}, pc: 4},
         );
         test_execute!(
             Instruction::CSRRC { rd: Register::TP, rs1: Register::A7, csr: 5 },
-            changes: {registers: {tp: 3, a7: 0b10010010}, csr: {5: 0b10000101}},
-            to: {registers: {tp: 0b10000101, a7: 0b10010010}, csr: {5: 0b00000101}, pc: 4},
+            executed_on: {registers: {tp: 3, a7: 0b10010010}, csr: {5: 0b10000101}},
+            results_in: {registers: {tp: 0b10000101, a7: 0b10010010}, csr: {5: 0b00000101}, pc: 4},
         );
     }
 
@@ -1002,13 +1002,13 @@ mod test {
     fn execute_csrs() {
         test_execute!(
             Instruction::CSRS(Register::S3, 42),
-            changes: {registers: {s3: 0}},
-            to: {registers: {s3: 0}, pc: 4},
+            executed_on: {registers: {s3: 0}},
+            results_in: {registers: {s3: 0}, pc: 4},
         );
         test_execute!(
             Instruction::CSRS(Register::S7, 5),
-            changes: {registers: {s7: 0b10010010}, csr: {5: 0b10000101}},
-            to: {registers: {s7: 0b10010010}, csr: {5: 0b10010111}, pc: 4},
+            executed_on: {registers: {s7: 0b10010010}, csr: {5: 0b10000101}},
+            results_in: {registers: {s7: 0b10010010}, csr: {5: 0b10010111}, pc: 4},
         );
     }
 
@@ -1016,13 +1016,13 @@ mod test {
     fn execute_csrc() {
         test_execute!(
             Instruction::CSRC(Register::S3, 42),
-            changes: {registers: {s3: 0}},
-            to: {registers: {s3: 0}, pc: 4},
+            executed_on: {registers: {s3: 0}},
+            results_in: {registers: {s3: 0}, pc: 4},
         );
         test_execute!(
             Instruction::CSRC(Register::SP, 5),
-            changes: {registers: {sp: 0b10010010}, csr: {5: 0b10000101}},
-            to: {registers: {sp: 0b10010010}, csr: {5: 0b00000101}, pc: 4},
+            executed_on: {registers: {sp: 0b10010010}, csr: {5: 0b10000101}},
+            results_in: {registers: {sp: 0b10010010}, csr: {5: 0b00000101}, pc: 4},
         );
     }
 
@@ -1030,13 +1030,13 @@ mod test {
     fn execute_csrrwi() {
         test_execute!(
             Instruction::CSRRWI { rd: Register::A0, imm: 12, csr: 20 },
-            changes: {registers: {a0: 3}},
-            to: {registers: {a0: 0}, csr: {20: 12}, pc: 4},
+            executed_on: {registers: {a0: 3}},
+            results_in: {registers: {a0: 0}, csr: {20: 12}, pc: 4},
         );
         test_execute!(
             Instruction::CSRRWI { rd: Register::T1, imm: 32, csr: 5 },
-            changes: {registers: {t1: 3}, csr: {5: 42}},
-            to: {registers: {t1: 42}, csr: {5: 32}, pc: 4},
+            executed_on: {registers: {t1: 3}, csr: {5: 42}},
+            results_in: {registers: {t1: 42}, csr: {5: 32}, pc: 4},
         );
     }
 
@@ -1044,18 +1044,18 @@ mod test {
     fn execute_csrrsi() {
         test_execute!(
             Instruction::CSRRSI { rd: Register::T2, imm: 12, csr: 20 },
-            changes: {registers: {t2: 3}},
-            to: {registers: {t2: 0}, csr: {20: 12}, pc: 4},
+            executed_on: {registers: {t2: 3}},
+            results_in: {registers: {t2: 0}, csr: {20: 12}, pc: 4},
         );
         test_execute!(
             Instruction::CSRRSI { rd: Register::S8, imm: 0, csr: 20 },
-            changes: {registers: {s8: 3}, csr: {20: 12}},
-            to: {registers: {s8: 12}, csr: {20: 12}, pc: 4},
+            executed_on: {registers: {s8: 3}, csr: {20: 12}},
+            results_in: {registers: {s8: 12}, csr: {20: 12}, pc: 4},
         );
         test_execute!(
             Instruction::CSRRSI { rd: Register::A6, imm: 0b01010, csr: 5 },
-            changes: {registers: {a6: 3}, csr: {5: 0b10000101}},
-            to: {registers: {a6: 0b10000101}, csr: {5: 0b10001111}, pc: 4},
+            executed_on: {registers: {a6: 3}, csr: {5: 0b10000101}},
+            results_in: {registers: {a6: 0b10000101}, csr: {5: 0b10001111}, pc: 4},
         );
     }
 
@@ -1063,18 +1063,18 @@ mod test {
     fn execute_csrrci() {
         test_execute!(
             Instruction::CSRRCI { rd: Register::RA, imm: 12, csr: 20 },
-            changes: {registers: {ra: 3}},
-            to: {registers: {ra: 0}, pc: 4},
+            executed_on: {registers: {ra: 3}},
+            results_in: {registers: {ra: 0}, pc: 4},
         );
         test_execute!(
             Instruction::CSRRSI { rd: Register::S9, imm: 0, csr: 20 },
-            changes: {registers: {s9: 30}, csr: {20: 12}},
-            to: {registers: {s9: 12}, csr: {20: 12}, pc: 4},
+            executed_on: {registers: {s9: 30}, csr: {20: 12}},
+            results_in: {registers: {s9: 12}, csr: {20: 12}, pc: 4},
         );
         test_execute!(
             Instruction::CSRRCI { rd: Register::TP, imm: 0b10101, csr: 5 },
-            changes: {registers: {tp: 3}, csr: {5: 0b10000101}},
-            to: {registers: {tp: 0b10000101}, csr: {5: 0b10000000}, pc: 4},
+            executed_on: {registers: {tp: 3}, csr: {5: 0b10000101}},
+            results_in: {registers: {tp: 0b10000101}, csr: {5: 0b10000000}, pc: 4},
         );
     }
 
@@ -1082,13 +1082,13 @@ mod test {
     fn execute_csrwi() {
         test_execute!(
             Instruction::CSRWI(42, 0),
-            changes: {registers: {}},
-            to: {registers: {}, pc: 4},
+            executed_on: {registers: {}},
+            results_in: {registers: {}, pc: 4},
         );
         test_execute!(
             Instruction::CSRWI(42, 5),
-            changes: {registers: {}, csr: {42: 42}},
-            to: {registers: {}, csr: {42: 5}, pc: 4},
+            executed_on: {registers: {}, csr: {42: 42}},
+            results_in: {registers: {}, csr: {42: 5}, pc: 4},
         );
     }
 
@@ -1096,13 +1096,13 @@ mod test {
     fn execute_csrsi() {
         test_execute!(
             Instruction::CSRSI(42, 0),
-            changes: {registers: {}},
-            to: {registers: {}, pc: 4},
+            executed_on: {registers: {}},
+            results_in: {registers: {}, pc: 4},
         );
         test_execute!(
             Instruction::CSRSI(5, 0b10101),
-            changes: {registers: {}, csr: {5: 0b10000101}},
-            to: {registers: {}, csr: {5: 0b10010101}, pc: 4},
+            executed_on: {registers: {}, csr: {5: 0b10000101}},
+            results_in: {registers: {}, csr: {5: 0b10010101}, pc: 4},
         );
     }
 
@@ -1110,13 +1110,13 @@ mod test {
     fn execute_csrci() {
         test_execute!(
             Instruction::CSRCI(42, 0),
-            changes: {registers: {}},
-            to: {registers: {}, pc: 4},
+            executed_on: {registers: {}},
+            results_in: {registers: {}, pc: 4},
         );
         test_execute!(
             Instruction::CSRCI(5, 0b10011),
-            changes: {registers: {}, csr: {5: 0b10000101}},
-            to: {registers: {}, csr: {5: 0b10000100}, pc: 4},
+            executed_on: {registers: {}, csr: {5: 0b10000101}},
+            results_in: {registers: {}, csr: {5: 0b10000100}, pc: 4},
         );
     }
 
@@ -1124,18 +1124,18 @@ mod test {
     fn execute_jal() {
         test_execute!(
             Instruction::JAL { rd: Register::RA, offset: 84 },
-            changes: {registers: {}},
-            to: {registers: {ra: 4}, pc: 84},
+            executed_on: {registers: {}},
+            results_in: {registers: {ra: 4}, pc: 84},
         );
         test_execute!(
             Instruction::JAL { rd: Register::ZERO, offset: 5000 },
-            changes: {registers: {}, pc: 5000},
-            to: {registers: {}, pc: 10000 },
+            executed_on: {registers: {}, pc: 5000},
+            results_in: {registers: {}, pc: 10000 },
         );
         test_execute!(
             Instruction::JAL { rd: Register::T0, offset: -15000 },
-            changes: {registers: {}, pc: 40000},
-            to: {registers: {t0: 40004}, pc: 25000 },
+            executed_on: {registers: {}, pc: 40000},
+            results_in: {registers: {t0: 40004}, pc: 25000 },
         );
         test_execute!(
             Instruction::JAL { rd: Register::RA, offset: -42 },
@@ -1148,18 +1148,18 @@ mod test {
     fn execute_jal_pseudoinstruction() {
         test_execute!(
             Instruction::JAL(84),
-            changes: {registers: {}},
-            to: {registers: {ra: 4}, pc: 84},
+            executed_on: {registers: {}},
+            results_in: {registers: {ra: 4}, pc: 84},
         );
         test_execute!(
             Instruction::JAL(1000),
-            changes: {registers: {}, pc: 5000},
-            to: {registers: {ra: 5004}, pc: 6000 },
+            executed_on: {registers: {}, pc: 5000},
+            results_in: {registers: {ra: 5004}, pc: 6000 },
         );
         test_execute!(
             Instruction::JAL(-42),
-            changes: {registers: {}, pc: 82},
-            to: {registers: {ra: 86}, pc: 40 },
+            executed_on: {registers: {}, pc: 82},
+            results_in: {registers: {ra: 86}, pc: 40 },
         );
         test_execute!(
             Instruction::JAL(-42),
@@ -1172,18 +1172,18 @@ mod test {
     fn execute_j() {
         test_execute!(
             Instruction::J(84),
-            changes: {registers: {}},
-            to: {registers: {}, pc: 84},
+            executed_on: {registers: {}},
+            results_in: {registers: {}, pc: 84},
         );
         test_execute!(
             Instruction::J(1000),
-            changes: {registers: {}, pc: 5000},
-            to: {registers: {}, pc: 6000 },
+            executed_on: {registers: {}, pc: 5000},
+            results_in: {registers: {}, pc: 6000 },
         );
         test_execute!(
             Instruction::J(-42),
-            changes: {registers: {}, pc: 82},
-            to: {registers: {}, pc: 40 },
+            executed_on: {registers: {}, pc: 82},
+            results_in: {registers: {}, pc: 40 },
         );
         test_execute!(
             Instruction::J(-42),
@@ -1196,23 +1196,23 @@ mod test {
     fn execute_jalr() {
         test_execute!(
             Instruction::JALR { rd: Register::RA, rs1: Register::ZERO, offset: 84 },
-            changes: {registers: {}},
-            to: {registers: {ra: 4}, pc: 84},
+            executed_on: {registers: {}},
+            results_in: {registers: {ra: 4}, pc: 84},
         );
         test_execute!(
             Instruction::JALR { rd: Register::ZERO, rs1: Register::A0, offset: 5000 },
-            changes: {registers: {a0: 5000}, pc: 5000},
-            to: {registers: {a0: 5000}, pc: 10000 },
+            executed_on: {registers: {a0: 5000}, pc: 5000},
+            results_in: {registers: {a0: 5000}, pc: 10000 },
         );
         test_execute!(
             Instruction::JALR { rd: Register::ZERO, rs1: Register::A0, offset: 5000 },
-            changes: {registers: {a0: 5005}, pc: 5000},
-            to: {registers: {a0: 5005}, pc: 10004 },
+            executed_on: {registers: {a0: 5005}, pc: 5000},
+            results_in: {registers: {a0: 5005}, pc: 10004 },
         );
         test_execute!(
             Instruction::JALR { rd: Register::T0, rs1: Register::T1, offset: -15000 },
-            changes: {registers: {t1: 40000}, pc: 4},
-            to: {registers: {t0: 8, t1: 40000}, pc: 25000 },
+            executed_on: {registers: {t1: 40000}, pc: 4},
+            results_in: {registers: {t0: 8, t1: 40000}, pc: 25000 },
         );
         test_execute!(
             Instruction::JALR { rd: Register::RA, rs1: Register::S3, offset: -42 },

--- a/src/instructions/jimm.rs
+++ b/src/instructions/jimm.rs
@@ -1,0 +1,119 @@
+//! A module including helpers for extracting the 21-bit immediate value out of
+//! an `J`-type instruction.
+
+/// For extracting and encoding the `J` immediate from a `J`-type instruction.
+///
+/// The immediate bits of the `J`-type instruction are organized as follows
+///
+/// |     31    |   30 - 21   |    20     |   19 - 12    | 11 - 7 |   6 - 0  |
+/// | --------- | ----------- | --------- | ------------ | ------ | -------- |
+/// | `imm[20]` | `imm[10:1]` | `imm[11]` | `imm[19:12]` |  `rd`  | `opcode` |
+/// |     1     |      10     |     1     |       8      |    5   |     7    |
+pub(super) struct JImm;
+
+impl JImm {
+    /// A mask for the bits that are in the correct position.
+    const FIX_POSITION_MASK: u32 = u32::from_le(0b_0000000_00000_11111_111_00000_0000000);
+    /// The mask for the sign bit
+    const SIGN_MASK: u32 = u32::from_le(0b_1000000_00000_00000_000_00000_0000000);
+    /// The shift for the signed bit
+    const SIGN_RSHIFT: usize = 11;
+    /// The mask for the signed bit
+    const INITIAL_BITS_MASK: u32 = u32::from_le(0b_0111111_11110_00000_000_00000_0000000);
+    /// The shift for the signed bit
+    const INITIAL_BITS_RSHIFT: usize = 20;
+    /// The mask for the middle bit
+    const MID_BIT_MASK: u32 = u32::from_le(0b_0000000_00001_00000_000_00000_0000000);
+    /// The shift for the signed bit
+    const MID_BIT_RSHIFT: usize = 9;
+
+    /// The lest significant bit should be zero
+    const FINAL_MASK: i32 = -2;
+
+    /// Decode the 21-bit immediate value from an `J`-type instruction.
+    #[inline]
+    pub(super) const fn decode(value: u32) -> i32 {
+        (((value & Self::FIX_POSITION_MASK) as i32)
+            + (((value & Self::SIGN_MASK) as i32) >> Self::SIGN_RSHIFT)
+            + (((value & Self::INITIAL_BITS_MASK) >> Self::INITIAL_BITS_RSHIFT) as i32)
+            + (((value & Self::MID_BIT_MASK) >> Self::MID_BIT_RSHIFT) as i32))
+            & Self::FINAL_MASK
+    }
+
+    /// Encode the 21-bit immediate value into an `J`-type instruction.
+    #[inline]
+    pub(super) const fn encode(value: i32) -> u32 {
+        let value = value as u32;
+        ((value << Self::SIGN_RSHIFT) & Self::SIGN_MASK)
+            + ((value << Self::INITIAL_BITS_RSHIFT) & Self::INITIAL_BITS_MASK)
+            + ((value << Self::MID_BIT_RSHIFT) & Self::MID_BIT_MASK)
+            + (value & Self::FIX_POSITION_MASK)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::integer::i21;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn decode() {
+        let instruction = u32::from_le(0b_0110110_10101_10110_011_10111_0010011);
+        assert_eq!(
+            JImm::decode(instruction),
+            i32::from_le(0b_0000000_00000_10110_011_1110110_10100)
+        );
+    }
+
+    #[test]
+    fn decode_all_the_ones() {
+        let instruction = u32::from_le(0b_1111111_11111_11111_111_10111_0010011);
+        // The expected answer is `-2 = -1 - 1` since the least significant bit is zero
+        assert_eq!(JImm::decode(instruction), -2);
+    }
+
+    #[test]
+    fn decode_min() {
+        let instruction = u32::from_le(0b_1000000_00000_00000_000_01000_0010011);
+        assert_eq!(JImm::decode(instruction), i21::MIN);
+    }
+
+    #[test]
+    fn decode_max() {
+        let instruction = u32::from_le(0b_0111111_11111_11111_111_11011_0010011);
+        // `-1` because the least significant bit is zero
+        assert_eq!(JImm::decode(instruction), i21::MAX - 1);
+    }
+
+    #[test]
+    fn encode() {
+        let instruction = u32::from_le(0b_0110110_10101_10110_011_00000_0000000);
+        println!(
+            "{:#034b}",
+            JImm::encode(i32::from_le(0b_0000000_00000_10110_011_1110110_10100))
+        );
+        assert_eq!(
+            JImm::encode(i32::from_le(0b_0000000_00000_10110_011_1110110_10100)),
+            instruction
+        );
+    }
+
+    #[test]
+    fn encode_negative_one() {
+        let instruction = u32::from_le(0b_1111111_11111_11111_111_00000_0000000);
+        assert_eq!(JImm::encode(-1), instruction);
+    }
+
+    #[test]
+    fn encode_min() {
+        let instruction = u32::from_le(0b_1000000_00000_00000_000_00000_0000000);
+        assert_eq!(JImm::encode(i21::MIN), instruction);
+    }
+
+    #[test]
+    fn encode_max() {
+        let instruction = u32::from_le(0b_0111111_11111_11111_111_00000_0000000);
+        assert_eq!(JImm::encode(i21::MAX), instruction);
+    }
+}

--- a/src/instructions/jimm.rs
+++ b/src/instructions/jimm.rs
@@ -89,10 +89,6 @@ mod test {
     #[test]
     fn encode() {
         let instruction = u32::from_le(0b_0110110_10101_10110_011_00000_0000000);
-        println!(
-            "{:#034b}",
-            JImm::encode(i32::from_le(0b_0000000_00000_10110_011_1110110_10100))
-        );
         assert_eq!(
             JImm::encode(i32::from_le(0b_0000000_00000_10110_011_1110110_10100)),
             instruction

--- a/src/instructions/mod.rs
+++ b/src/instructions/mod.rs
@@ -14,6 +14,7 @@ mod funct7;
 mod immi;
 mod immu;
 mod impl_instruction_set;
+mod jimm;
 mod pseudoinstructions;
 mod rd;
 mod rs1;

--- a/src/instructions/pseudoinstructions.rs
+++ b/src/instructions/pseudoinstructions.rs
@@ -414,6 +414,28 @@ impl Instruction {
             rs1: Register::RA,
             offset: 0,
         });
+
+    /// # Call far away subroutine
+    ///
+    /// Jump to the relative offset without linking the return address
+    ///
+    /// Note: This pseudoinstruction desugars to `AUIPC x1, imm[31:12]; JALR x1, x1, imm[11:0]`
+    /// See
+    /// [ref](https://github.com/riscv-non-isa/riscv-asm-manual/blob/master/riscv-asm.md#-a-listing-of-standard-risc-v-pseudoinstructions)
+    #[allow(non_snake_case)]
+    pub(crate) fn CALL(address: i32) -> PseudoinstructionMappingIter {
+        PseudoinstructionMappingIter::Two(
+            Instruction::AUIPC {
+                rd: Register::RA,
+                imm: (address >> ImmU::RSHIFT),
+            },
+            Instruction::JALR {
+                rd: Register::RA,
+                rs1: Register::RA,
+                offset: (address as i16) & i12::MASK,
+            },
+        )
+    }
 }
 
 /// If the `i12` value is negative returns `1` otherwise returns `0`.

--- a/src/instructions/pseudoinstructions.rs
+++ b/src/instructions/pseudoinstructions.rs
@@ -384,6 +384,22 @@ impl Instruction {
             offset: 0,
         })
     }
+
+    /// # Unconditional Jump register
+    ///
+    /// Jump to the relative offset without linking the return address
+    ///
+    /// Note: This pseudoinstruction desugars to `JALR x0, rs, 0`
+    /// See
+    /// [ref](https://github.com/riscv-non-isa/riscv-asm-manual/blob/master/riscv-asm.md#-a-listing-of-standard-risc-v-pseudoinstructions)
+    #[allow(non_snake_case)]
+    pub(crate) fn JR(rs: Register) -> PseudoinstructionMappingIter {
+        PseudoinstructionMappingIter::One(Instruction::JALR {
+            rd: Register::ZERO,
+            rs1: rs,
+            offset: 0,
+        })
+    }
 }
 
 /// If the `i12` value is negative returns `1` otherwise returns `0`.

--- a/src/instructions/pseudoinstructions.rs
+++ b/src/instructions/pseudoinstructions.rs
@@ -436,6 +436,28 @@ impl Instruction {
             },
         )
     }
+
+    /// # Tail call far away subroutine
+    ///
+    /// Jump to the address and tail call the subroutine.
+    ///
+    /// Note: This pseudoinstruction desugars to `AUIPC x6, imm[31:12]; JALR x0, x6, imm[11:0]`
+    /// See
+    /// [ref](https://github.com/riscv-non-isa/riscv-asm-manual/blob/master/riscv-asm.md#-a-listing-of-standard-risc-v-pseudoinstructions)
+    #[allow(non_snake_case)]
+    pub(crate) fn TAIL(address: i32) -> PseudoinstructionMappingIter {
+        PseudoinstructionMappingIter::Two(
+            Instruction::AUIPC {
+                rd: Register::T1,
+                imm: (address >> ImmU::RSHIFT),
+            },
+            Instruction::JALR {
+                rd: Register::ZERO,
+                rs1: Register::T1,
+                offset: (address as i16) & i12::MASK,
+            },
+        )
+    }
 }
 
 /// If the `i12` value is negative returns `1` otherwise returns `0`.

--- a/src/instructions/pseudoinstructions.rs
+++ b/src/instructions/pseudoinstructions.rs
@@ -368,6 +368,22 @@ impl Instruction {
             offset,
         })
     }
+
+    /// # Jump and link register
+    ///
+    /// Jump and link using the default return address register.
+    ///
+    /// Note: This pseudoinstruction desugars to `JALR x1, rs, 0`
+    /// See
+    /// [ref](https://github.com/riscv-non-isa/riscv-asm-manual/blob/master/riscv-asm.md#-a-listing-of-standard-risc-v-pseudoinstructions)
+    #[allow(non_snake_case)]
+    pub(crate) fn JALR(rs: Register) -> PseudoinstructionMappingIter {
+        PseudoinstructionMappingIter::One(Instruction::JALR {
+            rd: Register::RA,
+            rs1: rs,
+            offset: 0,
+        })
+    }
 }
 
 /// If the `i12` value is negative returns `1` otherwise returns `0`.

--- a/src/instructions/pseudoinstructions.rs
+++ b/src/instructions/pseudoinstructions.rs
@@ -338,6 +338,36 @@ impl Instruction {
             csr,
         })
     }
+
+    /// # Jump and link
+    ///
+    /// Jump and link using the default return address register.
+    ///
+    /// Note: This pseudoinstruction desugars to `JAL x1, offset`
+    /// See
+    /// [ref](https://github.com/riscv-non-isa/riscv-asm-manual/blob/master/riscv-asm.md#-a-listing-of-standard-risc-v-pseudoinstructions)
+    #[allow(non_snake_case)]
+    pub(crate) fn JAL(offset: i32) -> PseudoinstructionMappingIter {
+        PseudoinstructionMappingIter::One(Instruction::JAL {
+            rd: Register::RA,
+            offset,
+        })
+    }
+
+    /// # Unconditional Jump
+    ///
+    /// Jump to the relative offset without linking the return address
+    ///
+    /// Note: This pseudoinstruction desugars to `JAL x0, offset`
+    /// See
+    /// [ref](https://github.com/riscv-non-isa/riscv-asm-manual/blob/master/riscv-asm.md#-a-listing-of-standard-risc-v-pseudoinstructions)
+    #[allow(non_snake_case)]
+    pub(crate) fn J(offset: i32) -> PseudoinstructionMappingIter {
+        PseudoinstructionMappingIter::One(Instruction::JAL {
+            rd: Register::ZERO,
+            offset,
+        })
+    }
 }
 
 /// If the `i12` value is negative returns `1` otherwise returns `0`.

--- a/src/instructions/pseudoinstructions.rs
+++ b/src/instructions/pseudoinstructions.rs
@@ -400,6 +400,20 @@ impl Instruction {
             offset: 0,
         })
     }
+
+    /// # Return
+    ///
+    /// Return from a call to a subroutine.
+    ///
+    /// Note: This pseudoinstruction desugars to `JALR x0, x1, 0`
+    /// See
+    /// [ref](https://github.com/riscv-non-isa/riscv-asm-manual/blob/master/riscv-asm.md#-a-listing-of-standard-risc-v-pseudoinstructions)
+    pub(crate) const RET: PseudoinstructionMappingIter =
+        PseudoinstructionMappingIter::One(Instruction::JALR {
+            rd: Register::ZERO,
+            rs1: Register::RA,
+            offset: 0,
+        });
 }
 
 /// If the `i12` value is negative returns `1` otherwise returns `0`.

--- a/src/instructions/types.rs
+++ b/src/instructions/types.rs
@@ -13,11 +13,11 @@
 use crate::registers::Register;
 
 use super::{
-    csr::Csr, csr_imm::CsrImm, immi::ImmI, immu::ImmU, rd::Rd, rs1::Rs1, rs2::Rs2, shamt::Shamt,
-    simmi::SImmI,
+    csr::Csr, csr_imm::CsrImm, immi::ImmI, immu::ImmU, jimm::JImm, rd::Rd, rs1::Rs1, rs2::Rs2,
+    shamt::Shamt, simmi::SImmI,
 };
 
-/// `R`-type instructions - Register type instructions.
+/// `R`-type instruction - Register type instructions.
 pub(super) struct R;
 
 impl R {
@@ -27,7 +27,7 @@ impl R {
     }
 }
 
-/// `I`-type instructions - Immediate type instructions.
+/// `I`-type instruction - Immediate type instructions.
 pub(super) struct I;
 
 impl I {
@@ -56,7 +56,7 @@ impl I {
     }
 }
 
-/// `U`-type instructions - Upper immediate type instructions.
+/// `U`-type instruction - Upper immediate type instructions.
 pub(super) struct U;
 
 impl U {
@@ -67,12 +67,22 @@ impl U {
     }
 }
 
-/// `S`-type instructions - Store type instructions.
+/// `S`-type instruction - Store type instructions.
 pub(super) struct S;
 
 impl S {
     /// Encode the source registers and immediate value as an `S`-type instruction.
     pub(super) const fn encode(rs1: Register, rs2: Register, simmi: i16) -> u32 {
         Rs1::encode(rs1) + Rs2::encode(rs2) + SImmI::encode(simmi)
+    }
+}
+
+/// `J`-type instruction - Jump type instructions.
+pub(super) struct J;
+
+impl J {
+    /// Encode the destination register and offset value as an `J`-type instruction.
+    pub(super) const fn encode(rd: Register, offset: i32) -> u32 {
+        Rd::encode(rd) + JImm::encode(offset)
     }
 }

--- a/src/integer.rs
+++ b/src/integer.rs
@@ -27,6 +27,18 @@ pub(crate) mod i12 {
     }
 }
 
+/// The 21-bit signed integer type.
+pub(crate) mod i21 {
+    /// The largest value that can be represented by this integer type
+    /// (2<sup>20</sup> &minus; 1).
+    pub const MAX: i32 = 1048575;
+    /// The smallest value that can be represented by this integer type
+    /// (&minus;2<sup>20</sup>).
+    pub const MIN: i32 = -1048576;
+    /// The mask to extract an `i21` from a 16-bit integer type.
+    pub const MASK: i32 = 0b_0000_0000_0001_1111_1111_1111_1111_1111;
+}
+
 /// Conversion from a signed to an unsigned type.
 pub(crate) trait AsUnsigned<N> {
     /// Convert this to its associated unsigned type.

--- a/src/registers.rs
+++ b/src/registers.rs
@@ -568,6 +568,10 @@ pub(super) enum Register {
 }
 
 impl Register {
+    /// Frame pointer register.
+    ///
+    /// Actually an alias to register `S0`.
+    pub(super) const FP: Self = Self::S0;
     /// Converts the [u8] into a [Register].
     ///
     /// The [u8] will be masked to ensure it always returns a valid register.

--- a/src/test/macros.rs
+++ b/src/test/macros.rs
@@ -136,15 +136,27 @@ macro_rules! processor_state {
 ///
 /// # Example usage
 ///
+/// For a test where the expectation that the processor state will successfully
+/// be updated:
+///
 /// ```ignore
 /// test_execute!(
 ///     Instruction::CSRRW { rd: Register::A0, rs1: Register::S10, csr: 20 },
-///     changes: {registers: {a0: 3, s10: 12}},
-///     to: {registers: {a0: 0, s10: 12}, csr: {20: 12}, pc: 4},
+///     executed_on: {registers: {a0: 3, s10: 12}},
+///     results_in: {registers: {a0: 0, s10: 12}, csr: {20: 12}, pc: 4},
+/// );
+///
+/// For a test where the expectation is that an exception will be thrown:
+///
+/// ```ignore
+/// test_execute!(
+///     Instruction::JAL { rd: Register::RA, offset: -42 },
+///     executed_on: {registers: {}, pc: 84},
+///     throws: Exception::MisalignedInstructionFetch,
 /// );
 /// ```
 macro_rules! test_execute {
-    ($instruction:expr, changes: $initial_state:tt, to: $final_state:tt $(,)?) => {{
+    ($instruction:expr, executed_on: $initial_state:tt, results_in: $final_state:tt $(,)?) => {{
         // Arrange
         let mut processor = processor_state!($initial_state);
 
@@ -163,13 +175,13 @@ macro_rules! test_execute {
         let mut processor = processor_state!($initial_state);
 
         // Act
-        let result = $instruction.into_iter().try_for_each(|instruction| {
-            instruction.execute(&mut processor)
-        });
+        let result = $instruction
+            .into_iter()
+            .try_for_each(|instruction| instruction.execute(&mut processor));
 
         assert_eq!(result, Err($exception));
         assert_eq!(processor, processor_state!($initial_state));
-    }}
+    }};
 }
 
 /// Macro for creating a vec of instructions from a mixture of instructions and

--- a/src/test/macros.rs
+++ b/src/test/macros.rs
@@ -158,6 +158,18 @@ macro_rules! test_execute {
         assert_eq!(processor, expected_state);
         processor
     }};
+    ($instruction:expr, executed_on: $initial_state:tt, throws: $exception:expr $(,)?) => {{
+        // Arrange
+        let mut processor = processor_state!($initial_state);
+
+        // Act
+        let result = $instruction.into_iter().try_for_each(|instruction| {
+            instruction.execute(&mut processor)
+        });
+
+        assert_eq!(result, Err($exception));
+        assert_eq!(processor, processor_state!($initial_state));
+    }}
 }
 
 /// Macro for creating a vec of instructions from a mixture of instructions and

--- a/src/test/macros.rs
+++ b/src/test/macros.rs
@@ -182,6 +182,18 @@ macro_rules! test_execute {
         assert_eq!(result, Err($exception));
         assert_eq!(processor, processor_state!($initial_state));
     }};
+    ($instruction:expr, executed_on: $initial_state:tt, throws: $exception:expr, with_final_state: $final_state:tt $(,)?) => {{
+        // Arrange
+        let mut processor = processor_state!($initial_state);
+
+        // Act
+        let result = $instruction
+            .into_iter()
+            .try_for_each(|instruction| instruction.execute(&mut processor));
+
+        assert_eq!(result, Err($exception));
+        assert_eq!(processor, processor_state!($final_state));
+    }};
 }
 
 /// Macro for creating a vec of instructions from a mixture of instructions and


### PR DESCRIPTION
This PR makes the following changes.

# New instructions

This PR adds the following instructions:

- JAL - Jump and link
- JALR - Jump and link register

# New types and helpers

- `J`-type instruction helper
-  A new decoding/encoding helper `JImm` for the `J` immediate encoding.
- New Processor exception varient `MisalignedInstructionFetch`.

# Updated test macros

- Updated `test_execute` macro to support testing for processor exceptions.

# New pseudoinstructions

It also adds the following pseudoinstructions:

- JAL
- J
- JALR
- JR
- RET
- CALL
- TAIL

# Commits

- Add Jimm for encoding and decoding `J` immediate values
- Add jump and link instruction
- Add jal and j psuedoinstructions
- Add jalr instruction
- Update test macro DSL to match the exception version
- Implement JALR pseudoinstruction
- Implement JR pseudoinstruction
- Implement RET pseudoinstruction
- Implement CALL pseudoinstruction
- Implement TAIL pseudoinstruction
