### PR TITLE
Add branch instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,12 +55,12 @@ Feel free to contribute and get involved if you would like to learn more about a
   - [X] SW
   - [x] JAL
   - [x] JALR
-  - [ ] BEQ
-  - [ ] BNE
-  - [ ] BLT
-  - [ ] BGE
-  - [ ] BLTU
-  - [ ] BGEU
+  - [x] BEQ
+  - [x] BNE
+  - [x] BLT
+  - [x] BGE
+  - [x] BLTU
+  - [x] BGEU
 
 </details>
 

--- a/src/instructions/bimm.rs
+++ b/src/instructions/bimm.rs
@@ -1,0 +1,119 @@
+//! A module including helpers for extracting the `13`-bit immediate value out of
+//! an `B`-type instruction.
+
+/// For extracting and encoding the `B` immediate from a `B`-type instruction.
+///
+/// The immediate bits of the `B`-type instruction are organized as follows
+///
+/// |     31    |   30 - 25   | 24 - 20 | 19 - 15 | 14 - 12 |   11 - 8   |     7     |   6 - 0  |
+/// | --------- | ----------- | ------- | ------- | ------- | ---------- | --------- | -------- |
+/// | `imm[12]` | `imm[10:5]` |  `rs2`  |  `rs1`  | `func3` | `imm[4:1]` | `imm[11]` | `opcode` |
+/// |     1     |      6      |    5    |    5    |    3    |      4     |     1     |     7    |
+pub(super) struct BImm;
+
+impl BImm {
+    /// The mask for the sign bit
+    const SIGN_MASK: u32 = u32::from_le(0b_1000000_00000_00000_000_00000_0000000);
+    /// The shift for the signed bit
+    const SIGN_RSHIFT: usize = 19;
+    /// The mask for the middle bit
+    const LOW_BIT_MASK: u32 = u32::from_le(0b_0000000_00000_00000_000_00001_0000000);
+    /// The shift for the signed bit
+    const LOW_BIT_LSHIFT: usize = 4;
+    /// The mask for the sign bit
+    const UPPER_MASK: u32 = u32::from_le(0b_0111111_00000_00000_000_00000_0000000);
+    /// The shift for the signed bit
+    const UPPER_RSHIFT: usize = 20;
+    /// The mask for the sign bit
+    const LOW_MASK: u32 = u32::from_le(0b_0000000_00000_00000_000_11110_0000000);
+    /// The shift for the signed bit
+    const LOW_RSHIFT: usize = 7;
+    /// The lest significant bit should be zero
+    const FINAL_MASK: i16 = -2;
+
+    /// Decode the 13-bit immediate value from an `B`-type instruction.
+    #[inline]
+    pub(super) const fn decode(value: u32) -> i16 {
+        ((((value & Self::SIGN_MASK) as i32) >> Self::SIGN_RSHIFT)
+            + (((value & Self::LOW_BIT_MASK) as i32) << Self::LOW_BIT_LSHIFT)
+            + (((value & Self::UPPER_MASK) as i32) >> Self::UPPER_RSHIFT)
+            + (((value & Self::LOW_MASK) as i32) >> Self::LOW_RSHIFT)) as i16
+            & Self::FINAL_MASK
+    }
+
+    /// Encode the 13-bit immediate value into an `B`-type instruction.
+    #[inline]
+    pub(super) const fn encode(value: i16) -> u32 {
+        let value = value as u32;
+        ((value << Self::SIGN_RSHIFT) & Self::SIGN_MASK)
+            + ((value >> Self::LOW_BIT_LSHIFT) & Self::LOW_BIT_MASK)
+            + ((value << Self::UPPER_RSHIFT) & Self::UPPER_MASK)
+            + ((value << Self::LOW_RSHIFT) & Self::LOW_MASK)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::integer::i13;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn decode() {
+        let instruction = u32::from_le(0b_0110110_10101_10110_011_10111_0010011);
+        assert_eq!(
+            BImm::decode(instruction),
+            i16::from_le(0b_000_0_1_110110_10110)
+        );
+    }
+
+    #[test]
+    fn decode_negative_one() {
+        // This is not correct yet
+        let instruction = u32::from_le(0b_1111111_11011_01100_101_11111_0010011);
+        // The expected answer is `-2 = -1 - 1` since the least significant bit is zero
+        assert_eq!(BImm::decode(instruction), -2);
+    }
+
+    #[test]
+    fn decode_min() {
+        // This is not correct yet
+        let instruction = u32::from_le(0b_1000000_00100_01100_101_00000_0010011);
+        assert_eq!(BImm::decode(instruction), i13::MIN);
+    }
+
+    #[test]
+    fn decode_max() {
+        // This is not correct yet
+        let instruction = u32::from_le(0b_0111111_11011_01100_101_11111_0010011);
+        // `-1` because the least significant bit is zero
+        assert_eq!(BImm::decode(instruction), i13::MAX - 1);
+    }
+
+    #[test]
+    fn encode() {
+        let instruction = u32::from_le(0b_0110110_00000_00000_000_10101_0000000);
+        assert_eq!(
+            BImm::encode(i16::from_le(0b_000_0_1_110110_10100)),
+            instruction
+        );
+    }
+
+    #[test]
+    fn encode_negative_one() {
+        let instruction = u32::from_le(0b_1111111_00000_00000_000_11111_0000000);
+        assert_eq!(BImm::encode(-1), instruction);
+    }
+
+    #[test]
+    fn encode_min() {
+        let instruction = u32::from_le(0b_1000000_00000_00000_000_00000_0000000);
+        assert_eq!(BImm::encode(i13::MIN), instruction);
+    }
+
+    #[test]
+    fn encode_max() {
+        let instruction = u32::from_le(0b_0111111_00000_00000_000_11111_0000000);
+        assert_eq!(BImm::encode(i13::MAX), instruction);
+    }
+}

--- a/src/instructions/impl_instruction_set.rs
+++ b/src/instructions/impl_instruction_set.rs
@@ -1506,6 +1506,25 @@ mod test {
     }
 
     #[test]
+    fn execute_bgez() {
+        test_execute!(
+            Instruction::BGEZ(Register::RA, -44),
+            executed_on: {registers: {}, pc: 1000},
+            results_in: {registers: {}, pc: 956 },
+        );
+        test_execute!(
+            Instruction::BGEZ(Register::RA, -42),
+            executed_on: {registers: {ra: -1}, pc: 1000},
+            results_in: {registers: {ra: -1}, pc: 1004 },
+        );
+        test_execute!(
+            Instruction::BGEZ(Register::RA, -42),
+            executed_on: {registers: {ra: 1}, pc: 52},
+            throws: Exception::MisalignedInstructionFetch
+        );
+    }
+
+    #[test]
     fn execute_bltu() {
         test_execute!(
             Instruction::BLTU { rs1: Register::RA, rs2: Register::S3, offset: -44 },

--- a/src/instructions/impl_instruction_set.rs
+++ b/src/instructions/impl_instruction_set.rs
@@ -1458,6 +1458,35 @@ mod test {
     }
 
     #[test]
+    fn execute_ble() {
+        test_execute!(
+            Instruction::BLE(Register::RA, Register::S3, -44),
+            executed_on: {registers: {}, pc: 1000},
+            results_in: {registers: {}, pc: 956 },
+        );
+        test_execute!(
+            Instruction::BLE(Register::RA, Register::S3, -42),
+            executed_on: {registers: {s3: -1}, pc: 1000},
+            results_in: {registers: {s3: -1}, pc: 1004 },
+        );
+        test_execute!(
+            Instruction::BLE(Register::RA, Register::S3, -42),
+            executed_on: {registers: {ra: 41, s3: 42}, pc: 52},
+            throws: Exception::MisalignedInstructionFetch
+        );
+        test_execute!(
+            Instruction::BLE(Register::RA, Register::S3, -44),
+            executed_on: {registers: {ra: 43, s3: 42}, pc: 52},
+            results_in: {registers: {ra: 43, s3: 42}, pc: 56 },
+        );
+        test_execute!(
+            Instruction::BLE(Register::RA, Register::S3, -44),
+            executed_on: {registers: {ra: -42, s3: 43}, pc: 52},
+            results_in: {registers: {ra: -42, s3: 43}, pc: 8 },
+        );
+    }
+
+    #[test]
     fn execute_bltz() {
         test_execute!(
             Instruction::BLTZ(Register::RA, -44),

--- a/src/instructions/impl_instruction_set.rs
+++ b/src/instructions/impl_instruction_set.rs
@@ -1640,6 +1640,35 @@ mod test {
     }
 
     #[test]
+    fn execute_bgtu() {
+        test_execute!(
+            Instruction::BGTU(Register::RA, Register::S3, -44),
+            executed_on: {registers: {}, pc: 1000},
+            results_in: {registers: {}, pc: 1004 },
+        );
+        test_execute!(
+            Instruction::BGTU(Register::RA, Register::S3, -44),
+            executed_on: {registers: {s3: 1}, pc: 1000},
+            results_in: {registers: {s3: 1}, pc: 1004 },
+        );
+        test_execute!(
+            Instruction::BGTU(Register::RA, Register::S3, -42),
+            executed_on: {registers: {ra: 43, s3: 42}, pc: 52},
+            throws: Exception::MisalignedInstructionFetch
+        );
+        test_execute!(
+            Instruction::BGTU(Register::RA, Register::S3, -44),
+            executed_on: {registers: {ra: 41, s3: 42}, pc: 52},
+            results_in: {registers: {ra: 41, s3: 42}, pc: 56 },
+        );
+        test_execute!(
+            Instruction::BGTU(Register::RA, Register::S3, -44),
+            executed_on: {registers: {ra: 42, s3: -43}, pc: 52},
+            results_in: {registers: {ra: 42, s3: -43}, pc: 56 },
+        );
+    }
+
+    #[test]
     fn execute_bgeu() {
         test_execute!(
             Instruction::BGEU { rs1: Register::RA, rs2: Register::S3, offset: -44 },

--- a/src/instructions/impl_instruction_set.rs
+++ b/src/instructions/impl_instruction_set.rs
@@ -1544,6 +1544,25 @@ mod test {
     }
 
     #[test]
+    fn execute_bgtz() {
+        test_execute!(
+            Instruction::BGTZ(Register::RA, -44),
+            executed_on: {registers: {}, pc: 1000},
+            results_in: {registers: {}, pc: 1004 },
+        );
+        test_execute!(
+            Instruction::BGTZ(Register::RA, -42),
+            executed_on: {registers: {ra: -1}, pc: 1000},
+            results_in: {registers: {ra: -1}, pc: 1004 },
+        );
+        test_execute!(
+            Instruction::BGTZ(Register::RA, -42),
+            executed_on: {registers: {ra: 1}, pc: 52},
+            throws: Exception::MisalignedInstructionFetch
+        );
+    }
+
+    #[test]
     fn execute_bltu() {
         test_execute!(
             Instruction::BLTU { rs1: Register::RA, rs2: Register::S3, offset: -44 },

--- a/src/instructions/impl_instruction_set.rs
+++ b/src/instructions/impl_instruction_set.rs
@@ -1410,6 +1410,25 @@ mod test {
     }
 
     #[test]
+    fn execute_bnez() {
+        test_execute!(
+            Instruction::BNEZ(Register::RA, -44),
+            executed_on: {registers: {}, pc: 1000},
+            results_in: {registers: {}, pc: 1004 },
+        );
+        test_execute!(
+            Instruction::BNEZ(Register::RA, -42),
+            executed_on: {registers: {ra: 0}, pc: 1000},
+            results_in: {registers: {ra: 0}, pc: 1004 },
+        );
+        test_execute!(
+            Instruction::BNEZ(Register::RA, -42),
+            executed_on: {registers: {ra: 1}, pc: 52},
+            throws: Exception::MisalignedInstructionFetch
+        );
+    }
+
+    #[test]
     fn execute_blt() {
         test_execute!(
             Instruction::BLT { rs1: Register::RA, rs2: Register::S3, offset: -44 },

--- a/src/instructions/impl_instruction_set.rs
+++ b/src/instructions/impl_instruction_set.rs
@@ -1458,6 +1458,25 @@ mod test {
     }
 
     #[test]
+    fn execute_blez() {
+        test_execute!(
+            Instruction::BLEZ(Register::RA, -44),
+            executed_on: {registers: {}, pc: 1000},
+            results_in: {registers: {}, pc: 956 },
+        );
+        test_execute!(
+            Instruction::BLEZ(Register::RA, -42),
+            executed_on: {registers: {ra: 1}, pc: 1000},
+            results_in: {registers: {ra: 1}, pc: 1004 },
+        );
+        test_execute!(
+            Instruction::BLEZ(Register::RA, -42),
+            executed_on: {registers: {ra: -1}, pc: 52},
+            throws: Exception::MisalignedInstructionFetch
+        );
+    }
+
+    #[test]
     fn execute_bge() {
         test_execute!(
             Instruction::BGE { rs1: Register::RA, rs2: Register::S3, offset: -44 },

--- a/src/instructions/impl_instruction_set.rs
+++ b/src/instructions/impl_instruction_set.rs
@@ -210,6 +210,14 @@ impl InstructionSet for Instruction {
                     pc = processor.pc + offset as i32;
                 }
             }
+            Instruction::BNE { rs1, rs2, offset } => {
+                if processor.registers[rs1] != processor.registers[rs2] {
+                    if offset % 4 != 0 {
+                        return Err(Exception::MisalignedInstructionFetch);
+                    }
+                    pc = processor.pc + offset as i32;
+                }
+            }
         }
         processor.pc = pc;
         Ok(())
@@ -1322,6 +1330,30 @@ mod test {
             Instruction::BEQ { rs1: Register::RA, rs2: Register::S3, offset: -44 },
             executed_on: {registers: {ra: 42, s3: 42}, pc: 52},
             results_in: {registers: {ra: 42, s3: 42}, pc: 8 },
+        );
+    }
+
+    #[test]
+    fn execute_bne() {
+        test_execute!(
+            Instruction::BNE { rs1: Register::RA, rs2: Register::S3, offset: -44 },
+            executed_on: {registers: {}, pc: 1000},
+            results_in: {registers: {}, pc: 1004 },
+        );
+        test_execute!(
+            Instruction::BNE { rs1: Register::RA, rs2: Register::S3, offset: -44 },
+            executed_on: {registers: {ra: 1}, pc: 1000},
+            results_in: {registers: {ra: 1}, pc: 956 },
+        );
+        test_execute!(
+            Instruction::BNE { rs1: Register::RA, rs2: Register::S3, offset: -42 },
+            executed_on: {registers: {ra: 42, s3: 41}, pc: 52},
+            throws: Exception::MisalignedInstructionFetch
+        );
+        test_execute!(
+            Instruction::BNE { rs1: Register::RA, rs2: Register::S3, offset: -44 },
+            executed_on: {registers: {ra: 42, s3: 41}, pc: 52},
+            results_in: {registers: {ra: 42, s3: 41}, pc: 8 },
         );
     }
 }

--- a/src/instructions/impl_instruction_set.rs
+++ b/src/instructions/impl_instruction_set.rs
@@ -226,6 +226,14 @@ impl InstructionSet for Instruction {
                     pc = processor.pc + offset as i32;
                 }
             }
+            Instruction::BGE { rs1, rs2, offset } => {
+                if processor.registers[rs1] >= processor.registers[rs2] {
+                    if offset % 4 != 0 {
+                        return Err(Exception::MisalignedInstructionFetch);
+                    }
+                    pc = processor.pc + offset as i32;
+                }
+            }
         }
         processor.pc = pc;
         Ok(())
@@ -1391,6 +1399,35 @@ mod test {
             Instruction::BLT { rs1: Register::RA, rs2: Register::S3, offset: -44 },
             executed_on: {registers: {ra: -42, s3: 43}, pc: 52},
             results_in: {registers: {ra: -42, s3: 43}, pc: 8 },
+        );
+    }
+
+    #[test]
+    fn execute_bge() {
+        test_execute!(
+            Instruction::BGE { rs1: Register::RA, rs2: Register::S3, offset: -44 },
+            executed_on: {registers: {}, pc: 1000},
+            results_in: {registers: {}, pc: 956 },
+        );
+        test_execute!(
+            Instruction::BGE { rs1: Register::RA, rs2: Register::S3, offset: -44 },
+            executed_on: {registers: {ra: 1}, pc: 1000},
+            results_in: {registers: {ra: 1}, pc: 956 },
+        );
+        test_execute!(
+            Instruction::BGE { rs1: Register::RA, rs2: Register::S3, offset: -42 },
+            executed_on: {registers: {ra: 43, s3: 42}, pc: 52},
+            throws: Exception::MisalignedInstructionFetch
+        );
+        test_execute!(
+            Instruction::BGE { rs1: Register::RA, rs2: Register::S3, offset: -44 },
+            executed_on: {registers: {ra: 43, s3: 42}, pc: 52},
+            results_in: {registers: {ra: 43, s3: 42}, pc: 8 },
+        );
+        test_execute!(
+            Instruction::BGE { rs1: Register::RA, rs2: Register::S3, offset: -44 },
+            executed_on: {registers: {ra: -41, s3: 43}, pc: 52},
+            results_in: {registers: {ra: -41, s3: 43}, pc: 56 },
         );
     }
 }

--- a/src/instructions/impl_instruction_set.rs
+++ b/src/instructions/impl_instruction_set.rs
@@ -1696,4 +1696,33 @@ mod test {
             results_in: {registers: {ra: -41, s3: 43}, pc: 8 },
         );
     }
+
+    #[test]
+    fn execute_bleu() {
+        test_execute!(
+            Instruction::BLEU(Register::RA, Register::S3, -44),
+            executed_on: {registers: {}, pc: 1000},
+            results_in: {registers: {}, pc: 956 },
+        );
+        test_execute!(
+            Instruction::BLEU(Register::RA, Register::S3, -44),
+            executed_on: {registers: {ra: 1}, pc: 1000},
+            results_in: {registers: {ra: 1}, pc: 1004 },
+        );
+        test_execute!(
+            Instruction::BLEU(Register::RA, Register::S3, -42),
+            executed_on: {registers: {ra: 41, s3: 42}, pc: 5},
+            throws: Exception::MisalignedInstructionFetch
+        );
+        test_execute!(
+            Instruction::BLEU(Register::RA, Register::S3, -44),
+            executed_on: {registers: {ra: 41, s3: 42}, pc: 52},
+            results_in: {registers: {ra: 41, s3: 42}, pc: 8 },
+        );
+        test_execute!(
+            Instruction::BLEU(Register::RA, Register::S3, -44),
+            executed_on: {registers: {ra: 41, s3: -43}, pc: 52},
+            results_in: {registers: {ra: 41, s3: -43}, pc: 8 },
+        );
+    }
 }

--- a/src/instructions/impl_instruction_set.rs
+++ b/src/instructions/impl_instruction_set.rs
@@ -1367,6 +1367,25 @@ mod test {
     }
 
     #[test]
+    fn execute_beqz() {
+        test_execute!(
+            Instruction::BEQZ(Register::RA, -44),
+            executed_on: {registers: {}, pc: 1000},
+            results_in: {registers: {}, pc: 956 },
+        );
+        test_execute!(
+            Instruction::BEQZ(Register::RA, -42),
+            executed_on: {registers: {ra: 1}, pc: 1000},
+            results_in: {registers: {ra: 1}, pc: 1004 },
+        );
+        test_execute!(
+            Instruction::BEQZ(Register::RA, -42),
+            executed_on: {registers: {ra: 0}, pc: 52},
+            throws: Exception::MisalignedInstructionFetch
+        );
+    }
+
+    #[test]
     fn execute_bne() {
         test_execute!(
             Instruction::BNE { rs1: Register::RA, rs2: Register::S3, offset: -44 },

--- a/src/instructions/impl_instruction_set.rs
+++ b/src/instructions/impl_instruction_set.rs
@@ -218,6 +218,14 @@ impl InstructionSet for Instruction {
                     pc = processor.pc + offset as i32;
                 }
             }
+            Instruction::BLT { rs1, rs2, offset } => {
+                if processor.registers[rs1] < processor.registers[rs2] {
+                    if offset % 4 != 0 {
+                        return Err(Exception::MisalignedInstructionFetch);
+                    }
+                    pc = processor.pc + offset as i32;
+                }
+            }
         }
         processor.pc = pc;
         Ok(())
@@ -1354,6 +1362,35 @@ mod test {
             Instruction::BNE { rs1: Register::RA, rs2: Register::S3, offset: -44 },
             executed_on: {registers: {ra: 42, s3: 41}, pc: 52},
             results_in: {registers: {ra: 42, s3: 41}, pc: 8 },
+        );
+    }
+
+    #[test]
+    fn execute_blt() {
+        test_execute!(
+            Instruction::BLT { rs1: Register::RA, rs2: Register::S3, offset: -44 },
+            executed_on: {registers: {}, pc: 1000},
+            results_in: {registers: {}, pc: 1004 },
+        );
+        test_execute!(
+            Instruction::BLT { rs1: Register::RA, rs2: Register::S3, offset: -44 },
+            executed_on: {registers: {s3: 1}, pc: 1000},
+            results_in: {registers: {s3: 1}, pc: 956 },
+        );
+        test_execute!(
+            Instruction::BLT { rs1: Register::RA, rs2: Register::S3, offset: -42 },
+            executed_on: {registers: {ra: 41, s3: 42}, pc: 52},
+            throws: Exception::MisalignedInstructionFetch
+        );
+        test_execute!(
+            Instruction::BLT { rs1: Register::RA, rs2: Register::S3, offset: -44 },
+            executed_on: {registers: {ra: 43, s3: 42}, pc: 52},
+            results_in: {registers: {ra: 43, s3: 42}, pc: 56 },
+        );
+        test_execute!(
+            Instruction::BLT { rs1: Register::RA, rs2: Register::S3, offset: -44 },
+            executed_on: {registers: {ra: -42, s3: 43}, pc: 52},
+            results_in: {registers: {ra: -42, s3: 43}, pc: 8 },
         );
     }
 }

--- a/src/instructions/impl_instruction_set.rs
+++ b/src/instructions/impl_instruction_set.rs
@@ -1525,6 +1525,25 @@ mod test {
     }
 
     #[test]
+    fn execute_bgt() {
+        test_execute!(
+            Instruction::BGT(Register::RA, Register::T0, -44),
+            executed_on: {registers: {}, pc: 1000},
+            results_in: {registers: {}, pc: 1004 },
+        );
+        test_execute!(
+            Instruction::BGT(Register::RA, Register::T0, -42),
+            executed_on: {registers: {ra: -1, t0: 3}, pc: 1000},
+            results_in: {registers: {ra: -1, t0: 3}, pc: 1004 },
+        );
+        test_execute!(
+            Instruction::BGT(Register::RA, Register::T0,-42),
+            executed_on: {registers: {ra: 1, t0: -1}, pc: 52},
+            throws: Exception::MisalignedInstructionFetch
+        );
+    }
+
+    #[test]
     fn execute_bgez() {
         test_execute!(
             Instruction::BGEZ(Register::RA, -44),

--- a/src/instructions/impl_instruction_set.rs
+++ b/src/instructions/impl_instruction_set.rs
@@ -1458,6 +1458,25 @@ mod test {
     }
 
     #[test]
+    fn execute_bltz() {
+        test_execute!(
+            Instruction::BLTZ(Register::RA, -44),
+            executed_on: {registers: {}, pc: 1000},
+            results_in: {registers: {}, pc: 1004 },
+        );
+        test_execute!(
+            Instruction::BLTZ(Register::RA, -42),
+            executed_on: {registers: {ra: 1}, pc: 1000},
+            results_in: {registers: {ra: 1}, pc: 1004 },
+        );
+        test_execute!(
+            Instruction::BLTZ(Register::RA, -42),
+            executed_on: {registers: {ra: -1}, pc: 52},
+            throws: Exception::MisalignedInstructionFetch
+        );
+    }
+
+    #[test]
     fn execute_blez() {
         test_execute!(
             Instruction::BLEZ(Register::RA, -44),

--- a/src/instructions/mod.rs
+++ b/src/instructions/mod.rs
@@ -6,6 +6,7 @@
 //! This module also contains a number of helpers for exacting the different part of
 //! an encoded instruction.
 #![allow(clippy::unusual_byte_groupings, clippy::upper_case_acronyms)]
+mod bimm;
 mod csr;
 mod csr_imm;
 mod funct3;

--- a/src/instructions/pseudoinstructions.rs
+++ b/src/instructions/pseudoinstructions.rs
@@ -538,6 +538,22 @@ impl Instruction {
             offset,
         })
     }
+
+    /// # Branch greater than zero
+    ///
+    /// Branch if the value in register `rs` is greater than zero.
+    ///
+    /// Note: This pseudoinstruction desugars to `BLT x0, rs, offset`
+    /// See
+    /// [ref](https://github.com/riscv-non-isa/riscv-asm-manual/blob/master/riscv-asm.md#-a-listing-of-standard-risc-v-pseudoinstructions)
+    #[allow(non_snake_case)]
+    pub(crate) fn BGTZ(rs: Register, offset: i16) -> PseudoinstructionMappingIter {
+        PseudoinstructionMappingIter::One(Instruction::BLT {
+            rs1: Register::ZERO,
+            rs2: rs,
+            offset,
+        })
+    }
 }
 
 /// If the `i12` value is negative returns `1` otherwise returns `0`.

--- a/src/instructions/pseudoinstructions.rs
+++ b/src/instructions/pseudoinstructions.rs
@@ -570,6 +570,22 @@ impl Instruction {
             offset,
         })
     }
+
+    /// # Branch less than or equal
+    ///
+    /// Branch if the value in register `rs1` is less than or equal to the value in `rs2`.
+    ///
+    /// Note: This pseudoinstruction desugars to `BGE rs2, rs1, offset`
+    /// See
+    /// [ref](https://github.com/riscv-non-isa/riscv-asm-manual/blob/master/riscv-asm.md#-a-listing-of-standard-risc-v-pseudoinstructions)
+    #[allow(non_snake_case)]
+    pub(crate) fn BLE(rs1: Register, rs2: Register, offset: i16) -> PseudoinstructionMappingIter {
+        PseudoinstructionMappingIter::One(Instruction::BGE {
+            rs1: rs2,
+            rs2: rs1,
+            offset,
+        })
+    }
 }
 
 /// If the `i12` value is negative returns `1` otherwise returns `0`.

--- a/src/instructions/pseudoinstructions.rs
+++ b/src/instructions/pseudoinstructions.rs
@@ -474,6 +474,22 @@ impl Instruction {
             offset,
         })
     }
+
+    /// # Branch not equal to zero
+    ///
+    /// Branch if the value in register `rs` is not equal to zero.
+    ///
+    /// Note: This pseudoinstruction desugars to `BNE rs, x0, offset`
+    /// See
+    /// [ref](https://github.com/riscv-non-isa/riscv-asm-manual/blob/master/riscv-asm.md#-a-listing-of-standard-risc-v-pseudoinstructions)
+    #[allow(non_snake_case)]
+    pub(crate) fn BNEZ(rs: Register, offset: i16) -> PseudoinstructionMappingIter {
+        PseudoinstructionMappingIter::One(Instruction::BNE {
+            rs1: rs,
+            rs2: Register::ZERO,
+            offset,
+        })
+    }
 }
 
 /// If the `i12` value is negative returns `1` otherwise returns `0`.

--- a/src/instructions/pseudoinstructions.rs
+++ b/src/instructions/pseudoinstructions.rs
@@ -458,6 +458,22 @@ impl Instruction {
             },
         )
     }
+
+    /// # Branch equal to zero
+    ///
+    /// Branch if the value in register `rs` is equal to zero.
+    ///
+    /// Note: This pseudoinstruction desugars to `BEQ rs, x0, offset`
+    /// See
+    /// [ref](https://github.com/riscv-non-isa/riscv-asm-manual/blob/master/riscv-asm.md#-a-listing-of-standard-risc-v-pseudoinstructions)
+    #[allow(non_snake_case)]
+    pub(crate) fn BEQZ(rs: Register, offset: i16) -> PseudoinstructionMappingIter {
+        PseudoinstructionMappingIter::One(Instruction::BEQ {
+            rs1: rs,
+            rs2: Register::ZERO,
+            offset,
+        })
+    }
 }
 
 /// If the `i12` value is negative returns `1` otherwise returns `0`.

--- a/src/instructions/pseudoinstructions.rs
+++ b/src/instructions/pseudoinstructions.rs
@@ -554,6 +554,22 @@ impl Instruction {
             offset,
         })
     }
+
+    /// # Branch greater than
+    ///
+    /// Branch if the value in register `rs1` is greater than the value in `rs2`.
+    ///
+    /// Note: This pseudoinstruction desugars to `BLT rs2, rs1, offset`
+    /// See
+    /// [ref](https://github.com/riscv-non-isa/riscv-asm-manual/blob/master/riscv-asm.md#-a-listing-of-standard-risc-v-pseudoinstructions)
+    #[allow(non_snake_case)]
+    pub(crate) fn BGT(rs1: Register, rs2: Register, offset: i16) -> PseudoinstructionMappingIter {
+        PseudoinstructionMappingIter::One(Instruction::BLT {
+            rs1: rs2,
+            rs2: rs1,
+            offset,
+        })
+    }
 }
 
 /// If the `i12` value is negative returns `1` otherwise returns `0`.

--- a/src/instructions/pseudoinstructions.rs
+++ b/src/instructions/pseudoinstructions.rs
@@ -490,6 +490,22 @@ impl Instruction {
             offset,
         })
     }
+
+    /// # Branch less than or equal to zero
+    ///
+    /// Branch if the value in register `rs` is less than or equal to zero.
+    ///
+    /// Note: This pseudoinstruction desugars to `BGE x0, rs, offset`
+    /// See
+    /// [ref](https://github.com/riscv-non-isa/riscv-asm-manual/blob/master/riscv-asm.md#-a-listing-of-standard-risc-v-pseudoinstructions)
+    #[allow(non_snake_case)]
+    pub(crate) fn BLEZ(rs: Register, offset: i16) -> PseudoinstructionMappingIter {
+        PseudoinstructionMappingIter::One(Instruction::BGE {
+            rs1: Register::ZERO,
+            rs2: rs,
+            offset,
+        })
+    }
 }
 
 /// If the `i12` value is negative returns `1` otherwise returns `0`.

--- a/src/instructions/pseudoinstructions.rs
+++ b/src/instructions/pseudoinstructions.rs
@@ -590,7 +590,7 @@ impl Instruction {
     /// # Branch greater than unsigned
     ///
     /// Branch if the value in register `rs1` is greater than the value in `rs2`,
-    /// when using unsigend comparison.
+    /// when using unsigned comparison.
     ///
     /// Note: This pseudoinstruction desugars to `BLTU rs2, rs1, offset`
     /// See
@@ -598,6 +598,23 @@ impl Instruction {
     #[allow(non_snake_case)]
     pub(crate) fn BGTU(rs1: Register, rs2: Register, offset: i16) -> PseudoinstructionMappingIter {
         PseudoinstructionMappingIter::One(Instruction::BLTU {
+            rs1: rs2,
+            rs2: rs1,
+            offset,
+        })
+    }
+
+    /// # Branch less than or equal unsigned
+    ///
+    /// Branch if the value in register `rs1` is less than or equal to the value in `rs2`,
+    /// when using unsigned comparison.
+    ///
+    /// Note: This pseudoinstruction desugars to `BGEU rs2, rs1, offset`
+    /// See
+    /// [ref](https://github.com/riscv-non-isa/riscv-asm-manual/blob/master/riscv-asm.md#-a-listing-of-standard-risc-v-pseudoinstructions)
+    #[allow(non_snake_case)]
+    pub(crate) fn BLEU(rs1: Register, rs2: Register, offset: i16) -> PseudoinstructionMappingIter {
+        PseudoinstructionMappingIter::One(Instruction::BGEU {
             rs1: rs2,
             rs2: rs1,
             offset,

--- a/src/instructions/pseudoinstructions.rs
+++ b/src/instructions/pseudoinstructions.rs
@@ -586,6 +586,23 @@ impl Instruction {
             offset,
         })
     }
+
+    /// # Branch greater than unsigned
+    ///
+    /// Branch if the value in register `rs1` is greater than the value in `rs2`,
+    /// when using unsigend comparison.
+    ///
+    /// Note: This pseudoinstruction desugars to `BLTU rs2, rs1, offset`
+    /// See
+    /// [ref](https://github.com/riscv-non-isa/riscv-asm-manual/blob/master/riscv-asm.md#-a-listing-of-standard-risc-v-pseudoinstructions)
+    #[allow(non_snake_case)]
+    pub(crate) fn BGTU(rs1: Register, rs2: Register, offset: i16) -> PseudoinstructionMappingIter {
+        PseudoinstructionMappingIter::One(Instruction::BLTU {
+            rs1: rs2,
+            rs2: rs1,
+            offset,
+        })
+    }
 }
 
 /// If the `i12` value is negative returns `1` otherwise returns `0`.

--- a/src/instructions/pseudoinstructions.rs
+++ b/src/instructions/pseudoinstructions.rs
@@ -522,6 +522,22 @@ impl Instruction {
             offset,
         })
     }
+
+    /// # Branch less than zero
+    ///
+    /// Branch if the value in register `rs` is less than zero.
+    ///
+    /// Note: This pseudoinstruction desugars to `BLT rs, x0, offset`
+    /// See
+    /// [ref](https://github.com/riscv-non-isa/riscv-asm-manual/blob/master/riscv-asm.md#-a-listing-of-standard-risc-v-pseudoinstructions)
+    #[allow(non_snake_case)]
+    pub(crate) fn BLTZ(rs: Register, offset: i16) -> PseudoinstructionMappingIter {
+        PseudoinstructionMappingIter::One(Instruction::BLT {
+            rs1: rs,
+            rs2: Register::ZERO,
+            offset,
+        })
+    }
 }
 
 /// If the `i12` value is negative returns `1` otherwise returns `0`.

--- a/src/instructions/pseudoinstructions.rs
+++ b/src/instructions/pseudoinstructions.rs
@@ -506,6 +506,22 @@ impl Instruction {
             offset,
         })
     }
+
+    /// # Branch greater than or equal to zero
+    ///
+    /// Branch if the value in register `rs` greater than or equal to zero.
+    ///
+    /// Note: This pseudoinstruction desugars to `BGE rs, x0, offset`
+    /// See
+    /// [ref](https://github.com/riscv-non-isa/riscv-asm-manual/blob/master/riscv-asm.md#-a-listing-of-standard-risc-v-pseudoinstructions)
+    #[allow(non_snake_case)]
+    pub(crate) fn BGEZ(rs: Register, offset: i16) -> PseudoinstructionMappingIter {
+        PseudoinstructionMappingIter::One(Instruction::BGE {
+            rs1: rs,
+            rs2: Register::ZERO,
+            offset,
+        })
+    }
 }
 
 /// If the `i12` value is negative returns `1` otherwise returns `0`.

--- a/src/instructions/types.rs
+++ b/src/instructions/types.rs
@@ -13,8 +13,8 @@
 use crate::registers::Register;
 
 use super::{
-    csr::Csr, csr_imm::CsrImm, immi::ImmI, immu::ImmU, jimm::JImm, rd::Rd, rs1::Rs1, rs2::Rs2,
-    shamt::Shamt, simmi::SImmI,
+    bimm::BImm, csr::Csr, csr_imm::CsrImm, immi::ImmI, immu::ImmU, jimm::JImm, rd::Rd, rs1::Rs1,
+    rs2::Rs2, shamt::Shamt, simmi::SImmI,
 };
 
 /// `R`-type instruction - Register type instructions.
@@ -84,5 +84,15 @@ impl J {
     /// Encode the destination register and offset value as an `J`-type instruction.
     pub(super) const fn encode(rd: Register, offset: i32) -> u32 {
         Rd::encode(rd) + JImm::encode(offset)
+    }
+}
+
+/// `B`-type instruction - Branch type instructions.
+pub(super) struct B;
+
+impl B {
+    /// Encode the source registers and offset value as an `B`-type instruction.
+    pub(super) const fn encode(rs1: Register, rs2: Register, offset: i16) -> u32 {
+        Rs1::encode(rs1) + Rs2::encode(rs2) + BImm::encode(offset)
     }
 }

--- a/src/integer.rs
+++ b/src/integer.rs
@@ -27,6 +27,18 @@ pub(crate) mod i12 {
     }
 }
 
+/// The 13-bit signed integer type.
+pub(crate) mod i13 {
+    /// The largest value that can be represented by this integer type
+    /// (2<sup>20</sup> &minus; 1).
+    pub const MAX: i16 = 4095;
+    /// The smallest value that can be represented by this integer type
+    /// (&minus;2<sup>20</sup>).
+    pub const MIN: i16 = -4096;
+    /// The mask to extract an `i21` from a 16-bit integer type.
+    pub const MASK: i16 = 0b_0001_1111_1111_1111;
+}
+
 /// The 21-bit signed integer type.
 pub(crate) mod i21 {
     /// The largest value that can be represented by this integer type


### PR DESCRIPTION
This PR adds the branch instructions.

# Added instructions

- BEQ
- BNE
- BLT
- BGE
- BLTU
- BGEU

# Added pseudoinstructions

- BEQZ
- BNEZ
- BLEZ
- BGEZ
- BLTZ
- BGTZ
- BGT
- BLE
- BGTU
- BLEU


# Commits

- Add helper for decoding the branch immediate value
- Add BEQ instruction
- Add BNE instruction
- Add BLT instruction
- Add BGE instruction
- Add BLTU instruction
- Add BGEU instruction
- Add BEQZ pseudoinstruction
- Add BNEZ pseudoinstruction
- Add BLEZ pseudoinstruction
- Add BGEZ pseudoinstruction
- Add BLTZ pseudoinstruction
- Add BGTZ pseudoinstruction
- Add BGT pseudoinstruction
- Add BLE pseudoinstruction
- Add BGTU pseudoinstruction
- Add BLEU pseudoinstruction
- Update readme to include the added Branch instructions
